### PR TITLE
getProjectByUser should take no arguments in the 'Browsing' example

### DIFF
--- a/examples/0_Browsing.py
+++ b/examples/0_Browsing.py
@@ -50,7 +50,6 @@ if clientKey:
 else:
     myAPI = BaseSpaceAPI(profile='DEFAULT')
     
-    
 # First, let's grab the genome with id=4
 myGenome    = myAPI.getGenomeById('4')
 print "\nThe Genome is " + str(myGenome)
@@ -68,7 +67,7 @@ user        = myAPI.getUserById('current')
 print "\nThe current user is \n" + str(user)
 
 # Now list the projects for this user
-myProjects   = myAPI.getProjectByUser('current')
+myProjects   = myAPI.getProjectByUser()
 print "\nThe projects for this user are \n" + str(myProjects)
 
 # We can also achieve this by making a call using the 'user instance'


### PR DESCRIPTION
This fixes a bug in `0_Browsing.py`, whereby a parameter was given to `getProjectByUser`.  Without this, users may get the following exception:

```
Traceback (most recent call last):
  File "0_Browsing.py", line 71, in <module>
    myProjects   = myAPI.getProjectByUser('current')
  File "/Library/Python/2.7/site-packages/BaseSpacePy/api/BaseSpaceAPI.py", line 528, in getProjectByUser
    queryParams = self._validateQueryParameters(queryPars)               
  File "/Library/Python/2.7/site-packages/BaseSpacePy/api/BaseSpaceAPI.py", line 1222, in _validateQueryParameters
    raise QueryParameterException("Query parameter argument must be a QueryParameter object")
BaseSpacePy.api.BaseSpaceException.QueryParameterException: 'Error with query parameter: Query parameter argument must be a QueryParameter object'
```
