### PR TITLE
Python 2 and 3 compatibility; Continuous Integration; Static Analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ parts
 var
 sdist
 /scripts
+data/BC-12_S12_L001_R2_001.fastq.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+install: "cd src && python setup.py install && cd .."
+script: ./runtests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 install: "cd src && python setup.py install && cd .."
 script: ./runtests.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![Build Status](https://api.travis-ci.org/dtenenba/basespace-python-sdk.svg?branch=develop)
-
+[![Build Status][https://img.shields.io/travis/dtenenba/basespace-python-sdk.svg?style=flat&branch=develop]](https://travis-ci.org/dtenenba/basespace-python-sdk)
 
 INTRODUCTION
 =========================================

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-INTRODUCTION	
+![Build Status](https://api.travis-ci.org/dtenenba/basespace-python-sdk.svg?branch=develop)
+
+
+INTRODUCTION
 =========================================
 
-BaseSpacePy is a Python based SDK to be used in the development of Apps and scripts for working with Illumina's BaseSpace cloud-computing solution for next-gen sequencing data analysis. 
+BaseSpacePy is a Python based SDK to be used in the development of Apps and scripts for working with Illumina's BaseSpace cloud-computing solution for next-gen sequencing data analysis.
 
 The primary purpose of the SDK is to provide an easy-to-use Python environment enabling developers to authenticate a user, retrieve data, and upload data/results from their own analysis to BaseSpace.
 
@@ -39,7 +42,7 @@ If you do not have root access, you may use the --prefix to specify the install 
 
 	python setup.py install --prefix=/folder/in/my/pythonpath
 
-For more install options type: 
+For more install options type:
 
 	python setup.py --help
 
@@ -53,7 +56,7 @@ or add it to the PYTHONPATH at the top of your Python scripts using BaseSpacePy:
 	sys.path.append('/my/path/basespace-python-sdk/src')
 	import BaseSpacePy
 
-To test that everything is working as expected, launch a Python prompt and try importing 'BaseSpacePy': 
+To test that everything is working as expected, launch a Python prompt and try importing 'BaseSpacePy':
 
 	mkallberg@ubuntu:~/$ python
 	>>> import BaseSpacePy
@@ -115,7 +118,7 @@ Update to support changes in BaseSpace REST specification version v1pre3. Specif
 
 v 0.1
 -----------------------------------------
- 
+
 Initial release of BaseSpacePy
 
 COPYING / LICENSE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status][https://img.shields.io/travis/dtenenba/basespace-python-sdk.svg?style=flat&branch=develop]](https://travis-ci.org/dtenenba/basespace-python-sdk)
+[![Build Status][travis-image]](https://travis-ci.org/dtenenba/basespace-python-sdk)
+
+[travis-image]: https://img.shields.io/travis/dtenenba/basespace-python-sdk.svg?style=flat&branch=develop
 
 INTRODUCTION
 =========================================

--- a/doc/_update_doc/conf.py
+++ b/doc/_update_doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.txt'
 master_doc = 'index'
 
 # General information about the project.
-project = u'BaseSpacePy'
-copyright = u'2014, Illumina'
+project = 'BaseSpacePy'
+copyright = '2014, Illumina'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -183,8 +183,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'BaseSpacePy.tex', u'BaseSpacePy Documentation',
-   u'Illumina', 'manual'),
+  ('index', 'BaseSpacePy.tex', 'BaseSpacePy Documentation',
+   'Illumina', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -213,8 +213,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'basespacepy', u'BaseSpacePy Documentation',
-     [u'Illumina'], 1)
+    ('index', 'basespacepy', 'BaseSpacePy Documentation',
+     ['Illumina'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -227,8 +227,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'BaseSpacePy', u'BaseSpacePy Documentation',
-   u'Illumina', 'BaseSpacePy', 'One line description of project.',
+  ('index', 'BaseSpacePy', 'BaseSpacePy Documentation',
+   'Illumina', 'BaseSpacePy', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/examples/0_Browsing.py
+++ b/examples/0_Browsing.py
@@ -5,7 +5,7 @@ Copyright 2012 Illumina
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
     Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,11 +14,11 @@ limitations under the License.
 """
 
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
-import os 
+import os
 
 """
 This script demonstrates basic browsing of BaseSpace objects once an access-token
-for global browsing has been obtained. 
+for global browsing has been obtained.
 """
 
 """
@@ -30,8 +30,8 @@ filling in the clientKey, clientSecret, and accessToken (optionally appSessionId
 [DEFAULT]
 name = my new app
 clientKey =
-clientSecret = 
-accessToken = 
+clientSecret =
+accessToken =
 appSessionId =
 apiServer = https://api.cloud-hoth.illumina.com/
 apiVersion = v1pre3
@@ -49,35 +49,35 @@ if clientKey:
     myAPI = BaseSpaceAPI(clientKey, clientSecret, apiServer, apiVersion, appSessionId)
 else:
     myAPI = BaseSpaceAPI(profile='DEFAULT')
-    
+
 # First, let's grab the genome with id=4
 myGenome    = myAPI.getGenomeById('4')
-print "\nThe Genome is " + str(myGenome)
-print "We can get more information from the genome object"
-print 'Id: ' + myGenome.Id
-print 'Href: ' + myGenome.Href
-print 'DisplayName: ' + myGenome.DisplayName
+print("\nThe Genome is " + str(myGenome))
+print("We can get more information from the genome object")
+print('Id: ' + myGenome.Id)
+print('Href: ' + myGenome.Href)
+print('DisplayName: ' + myGenome.DisplayName)
 
 # Get a list of all genomes
 allGenomes  = myAPI.getAvailableGenomes()
-print "\nGenomes \n" + str(allGenomes)
+print("\nGenomes \n" + str(allGenomes))
 
 # Let's have a look at the current user
 user        = myAPI.getUserById('current')
-print "\nThe current user is \n" + str(user)
+print("\nThe current user is \n" + str(user))
 
 # Now list the projects for this user
 myProjects   = myAPI.getProjectByUser()
-print "\nThe projects for this user are \n" + str(myProjects)
+print("\nThe projects for this user are \n" + str(myProjects))
 
 # We can also achieve this by making a call using the 'user instance'
 myProjects2 = user.getProjects(myAPI)
-print "\nProjects retrieved from the user instance \n" + str(myProjects2)
+print("\nProjects retrieved from the user instance \n" + str(myProjects2))
 
 # List the runs available for the current user
 runs = user.getRuns(myAPI)
-print "\nThe runs for this user are \n" + str(runs)
+print("\nThe runs for this user are \n" + str(runs))
 
 # In the same manner we can get a list of accessible user runs
 runs = user.getRuns(myAPI)
-print "\nRuns retrieved from user instance \n" + str(runs)
+print("\nRuns retrieved from user instance \n" + str(runs))

--- a/examples/0_Browsing.py
+++ b/examples/0_Browsing.py
@@ -14,7 +14,6 @@ limitations under the License.
 """
 
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
-import os
 
 """
 This script demonstrates basic browsing of BaseSpace objects once an access-token

--- a/examples/1_AccessingFiles.py
+++ b/examples/1_AccessingFiles.py
@@ -14,7 +14,6 @@ limitations under the License.
 """
 
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
-import os
 """
 This script demonstrates how to access Samples and AppResults from a projects and how to work with the available
 file data for such instances.

--- a/examples/1_AccessingFiles.py
+++ b/examples/1_AccessingFiles.py
@@ -5,7 +5,7 @@ Copyright 2012 Illumina
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
     Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,14 +16,14 @@ limitations under the License.
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
 import os
 """
-This script demonstrates how to access Samples and AppResults from a projects and how to work with the available 
-file data for such instances. 
+This script demonstrates how to access Samples and AppResults from a projects and how to work with the available
+file data for such instances.
 """
 
 """
-NOTE: The coverage and variants API calls below require access to a public 
+NOTE: The coverage and variants API calls below require access to a public
 dataset. Before running the example, first go to cloud-hoth.illumina.com,
-login, click on Public Data, select the dataset named 'MiSeq B. cereus demo 
+login, click on Public Data, select the dataset named 'MiSeq B. cereus demo
 data', and click the Import button for the Project named 'BaseSpaceDemo'.
 """
 
@@ -51,40 +51,40 @@ myProjects      = myAPI.getProjectByUser('current')
 
 # Let's list all the AppResults and samples for these projects
 for singleProject in myProjects:
-    print "# " + str(singleProject)
+    print("# " + str(singleProject))
     appResults = singleProject.getAppResults(myAPI)
-    print "    The App results for project " + str(singleProject) + " are \n\t" + str(appResults)
+    print("    The App results for project " + str(singleProject) + " are \n\t" + str(appResults))
     samples = singleProject.getSamples(myAPI)
-    print "    The samples for project " + str(singleProject) + " are \n\t" + str(samples)
+    print("    The samples for project " + str(singleProject) + " are \n\t" + str(samples))
 #
-## we'll take a further look at the files belonging to the sample and 
-##analyses from the last project in the loop above 
+## we'll take a further look at the files belonging to the sample and
+##analyses from the last project in the loop above
 for a in appResults:
-    print "# " + a.Id
+    print("# " + a.Id)
     ff = a.getFiles(myAPI)
-    print ff
+    print(ff)
 for s in samples:
-    print "Sample " + str(s)
+    print("Sample " + str(s))
     ff = s.getFiles(myAPI)
-    print ff
+    print(ff)
 
 
-## Now let's do some work with files 
-## we'll grab a BAM by id and get the coverage for an interval + accompanying meta-data 
+## Now let's do some work with files
+## we'll grab a BAM by id and get the coverage for an interval + accompanying meta-data
 myBam = myAPI.getFileById('9895890')
-print myBam
+print(myBam)
 cov     = myBam.getIntervalCoverage(myAPI,'chr','1','100')
-print cov 
+print(cov)
 try:
    covMeta = myBam.getCoverageMeta(myAPI,'chr')
 except Exception as e:
-    print "Coverage metadata may not be available for this BAM file: %s" % str(e)
+    print("Coverage metadata may not be available for this BAM file: %s" % str(e))
 else:
-    print covMeta
+    print(covMeta)
 #
 ## and a vcf file
 myVCF = myAPI.getFileById('9895892')
 varMeta = myVCF.getVariantMeta(myAPI)
-print varMeta
-var     = myVCF.filterVariant(myAPI,'chr','1', '25000') 
-print var
+print(varMeta)
+var     = myVCF.filterVariant(myAPI,'chr','1', '25000')
+print(var)

--- a/examples/2_AppTriggering.py
+++ b/examples/2_AppTriggering.py
@@ -5,7 +5,7 @@ Copyright 2012 Illumina
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
     Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@ import webbrowser
 import time
 
 """
-This script demonstrates how to retrieve the AppSession object produced 
+This script demonstrates how to retrieve the AppSession object produced
 when a user initiates an app. Further it's demonstrated how to automatically
 generate the scope strings to request access to the data object (a project or a sample)
 that the app was triggered to analyze.
@@ -51,30 +51,30 @@ else:
 
 # Using the basespaceApi we can request the appSession object corresponding to the AppSession id supplied
 myAppSession = myAPI.getAppSession()
-print myAppSession
+print(myAppSession)
 
 # An app session contains a referal to one or more appLaunchObjects which reference the data module
-# the user launched the app on. This can be a list of projects, samples, or a mixture of objects  
-print "\nType of data the app was triggered on can be seen in 'references'"
-print myAppSession.References
+# the user launched the app on. This can be a list of projects, samples, or a mixture of objects
+print("\nType of data the app was triggered on can be seen in 'references'")
+print(myAppSession.References)
 
 # We can also get a handle to the user who started the AppSession
-print "\nWe can get a handle for the user who triggered the app\n" + str(myAppSession.UserCreatedBy)
+print("\nWe can get a handle for the user who triggered the app\n" + str(myAppSession.UserCreatedBy))
 
 # Let's have a closer look at the appSessionLaunchObject
 myReference =  myAppSession.References[0]
-print "\nWe can get out information such as the href to the launch object:"
-print myReference.HrefContent
-print "\nand the specific type of that object:"
-print myReference.Type
+print("\nWe can get out information such as the href to the launch object:")
+print(myReference.HrefContent)
+print("\nand the specific type of that object:")
+print(myReference.Type)
 
 
 # Now we will want to ask for more permission for the specific reference object
-print "\nWe can get out the specific project objects by using 'content':" 
+print("\nWe can get out the specific project objects by using 'content':")
 myReference =  myReference.Content
-print myReference
-print "\nThe scope string for requesting read access to the reference object is:"
-print myReference.getAccessStr(scope='write')
+print(myReference)
+print("\nThe scope string for requesting read access to the reference object is:")
+print(myReference.getAccessStr(scope='write'))
 
 # We can easily request write access to the reference object so our App can start contributing analysis
 # by default we ask for write permission and authentication for a device
@@ -82,21 +82,21 @@ print myReference.getAccessStr(scope='write')
 # We may limit our request to read access only if that's all that is needed
 #readAccessMaps  = myAPI.getAccess(myReference,accessType='read')
 
-#print "\nWe get the following access map for the write request"
-#print accessMap
+#print("\nWe get the following access map for the write request")
+#print(accessMap)
 
 ## PAUSE HERE
 # Have the user visit the verification uri to grant us access
-#print "\nPlease visit the uri within 15 seconds and grant access"
-#print accessMap['verification_with_code_uri']
+#print("\nPlease visit the uri within 15 seconds and grant access")
+#print(accessMap['verification_with_code_uri'])
 #webbrowser.open_new(accessMap['verification_with_code_uri'])
 #time.sleep(15)
 ## PAUSE HERE
 
 # Once the user has granted us the access to the object we requested we can
 # get the basespace access token and start browsing simply by calling updatePriviliges
-# on the baseSpaceApi instance    
+# on the baseSpaceApi instance
 #code = accessMap['device_code']
 #myAPI.updatePrivileges(code)
-#print "\nThe BaseSpaceAPI instance was update with write privileges"
-#print myAPI
+#print("\nThe BaseSpaceAPI instance was update with write privileges")
+#print(myAPI)

--- a/examples/2_AppTriggering.py
+++ b/examples/2_AppTriggering.py
@@ -14,8 +14,6 @@ limitations under the License.
 """
 
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
-import webbrowser
-import time
 
 """
 This script demonstrates how to retrieve the AppSession object produced

--- a/examples/3_Authentication.py
+++ b/examples/3_Authentication.py
@@ -12,11 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import six
-if six.PY2:
-    from __future__ import print_function
+from __future__ import print_function
 
-import sys
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
 import time
 import webbrowser

--- a/examples/3_Authentication.py
+++ b/examples/3_Authentication.py
@@ -5,26 +5,31 @@ Copyright 2012 Illumina
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
     Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import six
+if six.PY2:
+    from __future__ import print_function
 
 import sys
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
 import time
-import webbrowser 
-import cPickle as Pickle
+import webbrowser
 import os
 
+from six.moves import cPickle as Pickle
+
+
 """
-Demonstrates the basic BaseSpace authentication process The work-flow is as follows: 
+Demonstrates the basic BaseSpace authentication process The work-flow is as follows:
 scope-request -> user grants access -> browsing data. The scenario is demonstrated both for device and web-based apps.
 
-Further we demonstrate how a BaseSpaceAPI instance may be preserved across multiple http-request for the same app session using 
+Further we demonstrate how a BaseSpaceAPI instance may be preserved across multiple http-request for the same app session using
 python's pickle module.
 """
 
@@ -45,18 +50,18 @@ if clientKey:
     myAPI = BaseSpaceAPI(clientKey, clientSecret, apiServer, apiVersion, appSessionId)
 else:
     myAPI = BaseSpaceAPI(profile='DEFAULT')
-    
-    
+
+
 
 # First, get the verification code and uri for scope 'browse global'
 deviceInfo = myAPI.getVerificationCode('browse global')
-print "\n URL for user to visit and grant access: "
-print deviceInfo['verification_with_code_uri']
+print("\n URL for user to visit and grant access: ")
+print(deviceInfo['verification_with_code_uri'])
 
 ## PAUSE HERE
 # Have the user visit the verification uri to grant us access
-print "\nPlease visit the uri within 15 seconds and grant access"
-print deviceInfo['verification_with_code_uri']
+print("\nPlease visit the uri within 15 seconds and grant access")
+print(deviceInfo['verification_with_code_uri'])
 webbrowser.open_new(deviceInfo['verification_with_code_uri'])
 time.sleep(15)
 ## PAUSE HERE
@@ -68,13 +73,13 @@ code = deviceInfo['device_code']
 myAPI.updatePrivileges(code)
 
 # As a reference the provided access-token can be obtained from the BaseSpaceApi object
-print "\nMy Access-token:"
-print myAPI.getAccessToken()
+print("\nMy Access-token:")
+print(myAPI.getAccessToken())
 
 
-# Let's try and grab all available genomes with our new api! 
+# Let's try and grab all available genomes with our new api!
 allGenomes  = myAPI.getAvailableGenomes()
-print "\nGenomes \n" + str(allGenomes)
+print("\nGenomes \n" + str(allGenomes))
 
 
 # If at a later stage we wish to initialize a BaseSpaceAPI object when we already have
@@ -82,8 +87,8 @@ print "\nGenomes \n" + str(allGenomes)
 # object using the key-word AccessToken.
 myToken = myAPI.getAccessToken()
 myAPI.setAccessToken(myToken)
-print "\nA BaseSpaceAPI instance was updated with an access-token: "
-print myAPI 
+print("\nA BaseSpaceAPI instance was updated with an access-token: ")
+print(myAPI)
 
 #################### Web-based verification #################################
 # The scenario where the authentication is done through a web-browser
@@ -94,8 +99,8 @@ else:
     BSapiWeb = BaseSpaceAPI(profile='DEFAULT')
 userUrl= BSapiWeb.getWebVerificationCode('browse global','http://localhost',state='myState')
 
-print "\nHave the user visit:"
-print userUrl
+print("\nHave the user visit:")
+print(userUrl)
 
 webbrowser.open_new(userUrl)
 
@@ -109,20 +114,20 @@ myCode = '<MY DEVICE CODE FROM REDIRECT>'
 
 #################### Storing BaseSpaceApi using python's pickle module #################################
 """
-It may sometimes be useful to preserve certain api objects across a series of http requests from the same user-session. 
+It may sometimes be useful to preserve certain api objects across a series of http requests from the same user-session.
 Here we demonstrate how the Python pickle module may be used to achieve this end.
 
 The example will be for an instance of BaseSpaceAPI, but the same technique may be used for BaseSpaceAuth.
-In fact, a single instance of BaseSpaceAuth would be enough for a single App and could be shared by all http-requests, as the identity of 
-this object is only given by the client_key and client_secret. 
+In fact, a single instance of BaseSpaceAuth would be enough for a single App and could be shared by all http-requests, as the identity of
+this object is only given by the client_key and client_secret.
 
 (There is, of course, no problem in having multiple identical BaseSpaceAuth instances).
 """
 
 # Get current user
 user= myAPI.getUserById('current')
-print user
-print myAPI
+print(user)
+print(myAPI)
 
 #### Here some work goes on
 
@@ -134,9 +139,9 @@ f = open(mySessionId,'w')
 Pickle.dump(myAPI, f)
 f.close()
 
-# Imagine the current request is done, we will simulate this by deleting the api instance  
+# Imagine the current request is done, we will simulate this by deleting the api instance
 myAPI = None
-print "\nTry printing the removed API, we get: " + str(myAPI)
+print("\nTry printing the removed API, we get: " + str(myAPI))
 
 
 # Next request in the session with id = id123 comes in
@@ -145,10 +150,9 @@ if os.path.exists(mySessionId):
     f = open(mySessionId)
     myAPI = Pickle.load(f)
     f.close()
-    print 
-    print "We got the API back!"
-    print myAPI
+    print()
+    print("We got the API back!")
+    print(myAPI)
 else:
-    print "Looks like we haven't stored anything for this session yet"
+    print("Looks like we haven't stored anything for this session yet")
     # create a BaseSpaceAPI for the first time
-

--- a/examples/4_AppResultUpload.py
+++ b/examples/4_AppResultUpload.py
@@ -14,7 +14,6 @@ limitations under the License.
 """
 
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
-import os
 
 """
 This script demonstrates how to create a new AppResults object, change its state

--- a/examples/4_AppResultUpload.py
+++ b/examples/4_AppResultUpload.py
@@ -5,7 +5,7 @@ Copyright 2012 Illumina
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
     Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@ import os
 
 """
 This script demonstrates how to create a new AppResults object, change its state
-and upload result files to it and download files from it.  
+and upload result files to it and download files from it.
 """
 
 
@@ -43,47 +43,47 @@ else:
 
 # Now we'll do some work of our own. First get a project to work on
 # we'll need write permission, for the project we are working on
-# meaning we will need get a new token and instantiate a new BaseSpaceAPI  
+# meaning we will need get a new token and instantiate a new BaseSpaceAPI
 p = myAPI.getProjectById('89')
 
 # Assuming we have write access to the project
-# we will list the current App Results for the project 
+# we will list the current App Results for the project
 appRes = p.getAppResults(myAPI,statuses=['Running'])
-print "\nThe current running AppResults are \n" + str(appRes)
+print("\nThe current running AppResults are \n" + str(appRes))
 
 # now let's do some work!
 # to create an appResults for a project, simply give the name and description
 appResults = p.createAppResult(myAPI,"testing","this is my results",appSessionId='')
-print "\nSome info about our new app results"
-print appResults
-print appResults.Id
-print "\nThe app results also comes with a reference to our AppSession"
+print("\nSome info about our new app results")
+print(appResults)
+print(appResults.Id)
+print("\nThe app results also comes with a reference to our AppSession")
 myAppSession = appResults.AppSession
-print myAppSession
+print(myAppSession)
 
 # we can change the status of our AppSession and add a status-summary as follows
 myAppSession.setStatus(myAPI,'needsattention',"We worked hard, but encountered some trouble.")
-print "\nAfter a change of status of the app sessions we get\n" + str(myAppSession)
+print("\nAfter a change of status of the app sessions we get\n" + str(myAppSession))
 # we'll set our appSession back to running so we can do some more work
 myAppSession.setStatus(myAPI,'running',"Back on track")
 
 
-### Let's list all AppResults again and see if our new object shows up 
+### Let's list all AppResults again and see if our new object shows up
 appRes = p.getAppResults(myAPI,statuses=['Running'])
-print "\nThe updated app results are \n" + str(appRes)
+print("\nThe updated app results are \n" + str(appRes))
 appResult2 = myAPI.getAppResultById(appResults.Id)
-print appResult2
+print(appResult2)
 
-## Now we will make another AppResult 
+## Now we will make another AppResult
 ## and try to upload a file to it
 appResults2 = p.createAppResult(myAPI,"My second AppResult","This one I will upload to")
 appResults2.uploadFile(myAPI, '/home/mkallberg/Desktop/testFile2.txt', 'BaseSpaceTestFile.txt', '/mydir/', 'text/plain')
-print "\nMy AppResult number 2 \n" + str(appResults2)
+print("\nMy AppResult number 2 \n" + str(appResults2))
 
 ## let's see if our new file made it
 appResultFiles = appResults2.getFiles(myAPI)
-print "\nThese are the files in the appResult"
-print appResultFiles
+print("\nThese are the files in the appResult")
+print(appResultFiles)
 f = appResultFiles[-1]
 
 # we can even download our newly uploaded file

--- a/examples/5_Purchasing.py
+++ b/examples/5_Purchasing.py
@@ -5,7 +5,7 @@ Copyright 2012 Illumina
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
     Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ product_id                 = "" # from dev portal Pricing tab
 if not client_key:
     raise Exception("Please fill in client values (in the script) before running the script")
 
-# Create a client for making calls for this user session 
+# Create a client for making calls for this user session
 billAPI   = BillingAPI(BaseSpaceStoreUrl, version, AppSessionId, AccessToken=accessToken)
 
 # create a non-consumable purchase
@@ -49,43 +49,43 @@ billAPI   = BillingAPI(BaseSpaceStoreUrl, version, AppSessionId, AccessToken=acc
 
 # create a consumable purchase, and associated it with an AppSession
 # also add tags to provide (fake) details about the purchase
-print "\nCreating purchase\n"
+print("\nCreating purchase\n")
 purch = billAPI.createPurchase({'id':product_id,'quantity':4, 'tags':["test","test_tag"] }, AppSessionId)
 
 # record the purchase Id and RefundSecret for refunding later
 purchaseId = purch.Id
 refundSecret = purch.RefundSecret
 
-print "Now complete the purchase in your web browser"
-print "CLOSE the browser window/tab after you click 'Purchase' (and don't proceed into the app)"
+print("Now complete the purchase in your web browser")
+print("CLOSE the browser window/tab after you click 'Purchase' (and don't proceed into the app)")
 time.sleep(3)
 ## PAUSE HERE
-print "Opening: " + purch.HrefPurchaseDialog
+print("Opening: " + purch.HrefPurchaseDialog)
 webbrowser.open_new(purch.HrefPurchaseDialog)
-print "Waiting 30 seconds..."
+print("Waiting 30 seconds...")
 time.sleep(30)
 ## PAUSE HERE
 
-print "\nConfirm the purchase"
+print("\nConfirm the purchase")
 post_purch = billAPI.getPurchaseById(purchaseId)
-print "The status of the purchase is now: " + post_purch.Status
+print("The status of the purchase is now: " + post_purch.Status)
 
-print "\nRefunding the Purchase"
+print("\nRefunding the Purchase")
 # note we must use the same access token that was provided used for the purchase
 refunded_purchase = billAPI.refundPurchase(purchaseId, refundSecret, comment='the product did not function well as a frisbee')
 
-print "\nGetting all purchases for the current user with the tags we used for the purchase above"
+print("\nGetting all purchases for the current user with the tags we used for the purchase above")
 purch_prods = billAPI.getUserProducts(Id='current', queryPars=qpp( {'Tags':'test,test_tag'} ))
 if not len(purch_prods):
-    print "\nHmmm, didn't find any purchases with these tags. Did everything go OK above?\n"
+    print("\nHmmm, didn't find any purchases with these tags. Did everything go OK above?\n")
 else:
-    print "\nFor the first of these purchases:\n"
-    print "Purchase Name: " + purch_prods[0].Name
-    print "Purchase Price: " + purch_prods[0].Price
-    print "Purchase Quantity: " + purch_prods[0].Quantity
-    print "Tags: " + str(purch_prods[0].Tags)
+    print("\nFor the first of these purchases:\n")
+    print("Purchase Name: " + purch_prods[0].Name)
+    print("Purchase Price: " + purch_prods[0].Price)
+    print("Purchase Quantity: " + purch_prods[0].Quantity)
+    print("Tags: " + str(purch_prods[0].Tags))
 
     # Get the refund status of the purchase
-    print "\nGetting the (refunded) Purchase we just made"
+    print("\nGetting the (refunded) Purchase we just made")
     get_purch = billAPI.getPurchaseById(purch_prods[0].PurchaseId)
-    print "Refund Status: " + get_purch.RefundStatus + "\n"
+    print("Refund Status: " + get_purch.RefundStatus + "\n")

--- a/examples/5_Purchasing.py
+++ b/examples/5_Purchasing.py
@@ -12,10 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import os
 import webbrowser
 import time
-from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
 from BaseSpacePy.api.BillingAPI import BillingAPI
 from BaseSpacePy.model.QueryParametersPurchasedProduct import QueryParametersPurchasedProduct as qpp
 """

--- a/runtests.sh
+++ b/runtests.sh
@@ -16,4 +16,8 @@ cat test/dotbasespace/unit_tests.cfg | sed "s/__ACCESS_TOKEN__/$ACCESS_TOKEN/" >
 cp ~/.basespace/unit_tests.cfg ~/.basespace/default.cfg
 
 
-python test/unit_tests.py
+# python test/unit_tests.py
+
+ls /jhlkjgfhlkjghdsdsdsds
+
+exit $?

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+mkdir ~/.basespace
+
+cp test/dotbasespace/*.bash ~/.basespace
+cp test/dotbasespace/*.json ~/.basespace
+
+cd data
+curl -O https://s3.amazonaws.com/basespace-sdk-unit-test-data/BC-12_S12_L001_R2_001.fastq.gz
+cd ..
+
+# ...
+cat test/dotbasespace/unit_tests.cfg | sed "s/__ACCESS_TOKEN__/$ACCESS_TOKEN/" > ~/.basespace/unit_tests.cfg
+cp ~/.basespace/unit_tests.cfg ~/.basespace/default.cfg
+
+
+python test/unit_tests.py

--- a/runtests.sh
+++ b/runtests.sh
@@ -21,6 +21,8 @@ echo
 echo "Static analysis warnings from pyflakes:"
 echo
 # exclude doc directory because those files are auto-generated
+# the "|| true" at the end causes CI not to fail. In future
+# you could remove that if you want pyflakes warnings to break the build.
 find .  \( -path ./doc -o -path ./src/build \) -prune -o -name '*.py' -print | xargs pyflakes || true
 
 # TODO add stricter flake8 checking here

--- a/runtests.sh
+++ b/runtests.sh
@@ -15,6 +15,10 @@ cd ..
 cat test/dotbasespace/unit_tests.cfg | sed "s/__ACCESS_TOKEN__/$ACCESS_TOKEN/" > ~/.basespace/unit_tests.cfg
 cp ~/.basespace/unit_tests.cfg ~/.basespace/default.cfg
 
+pip install pyflakes
+
+find .  \( -path ./doc -o -path ./src/build \) -prune -o -name '*.py' -print | xargs pyflakes || true
+
 
 python test/unit_tests.py
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -16,8 +16,7 @@ cat test/dotbasespace/unit_tests.cfg | sed "s/__ACCESS_TOKEN__/$ACCESS_TOKEN/" >
 cp ~/.basespace/unit_tests.cfg ~/.basespace/default.cfg
 
 
-# python test/unit_tests.py
+python test/unit_tests.py
 
-ls /jhlkjgfhlkjghdsdsdsds
 
 exit $?

--- a/runtests.sh
+++ b/runtests.sh
@@ -17,7 +17,19 @@ cp ~/.basespace/unit_tests.cfg ~/.basespace/default.cfg
 
 pip install pyflakes
 
+echo
+echo "Static analysis warnings from pyflakes:"
+echo
+# exclude doc directory because those files are auto-generated
 find .  \( -path ./doc -o -path ./src/build \) -prune -o -name '*.py' -print | xargs pyflakes || true
+
+# TODO add stricter flake8 checking here
+# (checks for proper formatting of code in compliance with PEP8)
+
+
+echo
+echo "Unit test output:"
+echo
 
 
 python test/unit_tests.py

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 mkdir ~/.basespace
 
 cp test/dotbasespace/*.bash ~/.basespace

--- a/src/BaseSpacePy/api/APIClient.passes2.py
+++ b/src/BaseSpacePy/api/APIClient.passes2.py
@@ -2,8 +2,12 @@
 import sys
 import os
 import re
+import urllib
+import urllib2
 import io
+import cStringIO
 import json
+import logging
 from subprocess import *
 import subprocess
 import dateutil.parser
@@ -11,11 +15,8 @@ from warnings import warn
 from BaseSpacePy.model import *
 from BaseSpacePy.api.BaseSpaceException import RestMethodException, ServerResponseException
 
-
+from six.moves import urllib as six_urllib
 import six
-from six import moves
-from six.moves import urllib
-
 
 class APIClient:
     def __init__(self, AccessToken, apiServerAndVersion, userAgent=None, timeout=10):
@@ -48,7 +49,8 @@ class APIClient:
             pass
         import logging
         logging.getLogger("requests").setLevel(logging.WARNING)
-        encodedPost =  urllib.parse.urlencode(postData)
+        encodedPost =  urllib.urlencode(postData)
+        # encodedPost = six_urllib.parse.urlencode(postData)
         resourcePath = "%s?%s" % (resourcePath, encodedPost)
         response = requests.post(resourcePath, data=json.dumps(postData), headers=headers)
         return response.text
@@ -66,7 +68,7 @@ class APIClient:
         # cmd = 'curl -H "x-access-token:' + self.apiKey + '" -H "Content-MD5:' + headers['Content-MD5'].strip() +'" -T "'+ transFile +'" -X PUT ' + resourcePath
         # p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=STDOUT, close_fds=True)
         # output = p.stdout.read()
-        # print(output)
+        # print output
         # return output
         import requests
         put_headers = {
@@ -103,10 +105,12 @@ class APIClient:
         if self.userAgent:
             headers['User-Agent'] = self.userAgent
         if headerParams:
-            for param, value in six.iteritems(headerParams):
+            for param, value in headerParams.iteritems():
+            # for param, value in six.iteritems(headerParams):
                 headers[param] = value
         # specify the content type
-        if not 'Content-Type' in headers and not method=='PUT' and not forcePost:
+        if not headers.has_key('Content-Type') and not method=='PUT' and not forcePost:
+        # if not 'Content-Type' in headers and not method=='PUT' and not forcePost:
             headers['Content-Type'] = 'application/json'
         # include access token in header
         headers['Authorization'] = 'Bearer ' + self.apiKey
@@ -116,20 +120,23 @@ class APIClient:
             if queryParams:
                 # Need to remove None values, these should not be sent
                 sentQueryParams = {}
-                for param, value in six.iteritems(queryParams):
+                for param, value in queryParams.iteritems():
                     if value != None:
                         sentQueryParams[param] = value
-                url = url + '?' + urllib.parse.urlencode(sentQueryParams)
-            request = urllib.request.Request(url=url, headers=headers)
+                url = url + '?' + urllib.urlencode(sentQueryParams)
+                # url = url + '?' + six_urllib.parse.urlencode(sentQueryParams)
+            request = urllib2.Request(url=url, headers=headers)
+            # request = six_urllib.request.Request(url=url, headers=headers)
         elif method in ['POST', 'PUT', 'DELETE']:
             if queryParams:
                 # Need to remove None values, these should not be sent
                 sentQueryParams = {}
-                for param, value in six.iteritems(queryParams):
+                for param, value in queryParams.iteritems():
                     if value != None:
                         sentQueryParams[param] = value
                 forcePostUrl = url
-                url = url + '?' + urllib.parse.urlencode(sentQueryParams)
+                url = url + '?' + urllib.urlencode(sentQueryParams)
+                # url = url + '?' + six_urllib.parse.urlencode(sentQueryParams)
             data = postData
             if data:
                 if type(postData) not in [str, int, float, bool]:
@@ -137,9 +144,13 @@ class APIClient:
             if not forcePost:
                 if data and not len(data):
                     data='\n' # temp fix, in case is no data in the file, to prevent post request from failing
-                if data and six.PY3:
+            # THIS IS IT!!!!! :
+                if isinstance(data, unicode):
+                    # logging.info("dante data class is %s" % data.__class__)
                     data = data.encode('utf-8')
-                request = urllib.request.Request(url=url, headers=headers, data=data)#,timeout=self.timeout)
+                    # pass
+
+                request = urllib2.Request(url=url, headers=headers, data=data)#,timeout=self.timeout)
             else:
                 response = self.__forcePostCall__(forcePostUrl, sentQueryParams, headers)
             if method in ['PUT', 'DELETE']:
@@ -153,10 +164,10 @@ class APIClient:
         # Make the request
         if not forcePost and not method in ['PUT', 'DELETE']: # the normal case
             try:
-             response = urllib.request.urlopen(request, timeout=self.timeout).read().decode('utf-8')
-            except urllib.error.HTTPError as e:
-                response = e.read().decode('utf-8') # treat http error as a response (handle in caller)
-            except urllib.error.URLError as e:
+             response = urllib2.urlopen(request, timeout=self.timeout).read()
+            except urllib2.HTTPError as e:
+                response = e.read() # treat http error as a response (handle in caller)
+            except urllib2.URLError as e:
                 raise ServerResponseException('URLError: ' + str(e))
         try:
             data = json.loads(response)
@@ -195,7 +206,7 @@ class APIClient:
         # For dynamic types, substitute real class after looking up 'Type' value.
         # For lists, deserialize all members of a list, including lists of lists (though not list of list of list...).
         # For datetimes, convert to a readable output string
-        for attr, attrType in six.iteritems(instance.swaggerTypes):
+        for attr, attrType in instance.swaggerTypes.iteritems():
             if attr in obj:
                 value = obj[attr]
                 if attrType in ['str', 'int', 'float', 'bool']:
@@ -203,7 +214,7 @@ class APIClient:
                     try:
                         value = attrType(value)
                     except UnicodeEncodeError:
-                        value = six.text_type(value)
+                        value = unicode(value)
                     setattr(instance, attr, value)
                 elif attrType == 'DynamicType':
                     try:

--- a/src/BaseSpacePy/api/APIClient.py
+++ b/src/BaseSpacePy/api/APIClient.py
@@ -130,13 +130,14 @@ class APIClient:
                 url = url + '?' + urllib.parse.urlencode(sentQueryParams)
             data = postData
             if data:
-                if type(postData) not in [str, int, float, bool]:
+                if type(postData) not in [str, int, float, bool, bytes]:
                     data = json.dumps(postData)
             if not forcePost:
                 if data and not len(data):
                     data='\n' # temp fix, in case is no data in the file, to prevent post request from failing
                 if data and six.PY3:
-                    data = data.encode('utf-8')
+                    if type(data) is str:
+                        data = data.encode()
                 request = urllib.request.Request(url=url, headers=headers, data=data)#,timeout=self.timeout)
             else:
                 response = self.__forcePostCall__(forcePostUrl, sentQueryParams, headers)

--- a/src/BaseSpacePy/api/APIClient.py
+++ b/src/BaseSpacePy/api/APIClient.py
@@ -4,8 +4,6 @@ import os
 import re
 import io
 import json
-from subprocess import *
-import subprocess
 import dateutil.parser
 from warnings import warn
 from BaseSpacePy.model import *

--- a/src/BaseSpacePy/api/APIClient.py
+++ b/src/BaseSpacePy/api/APIClient.py
@@ -137,7 +137,8 @@ class APIClient:
             if not forcePost:
                 if data and not len(data):
                     data='\n' # temp fix, in case is no data in the file, to prevent post request from failing
-                if isinstance(data, unicode):
+                # if isinstance(data, unicode):
+                if data and six.PY3:
                     data = data.encode('utf-8')
                 request = urllib.request.Request(url=url, headers=headers, data=data)#,timeout=self.timeout)
             else:

--- a/src/BaseSpacePy/api/APIClient.py
+++ b/src/BaseSpacePy/api/APIClient.py
@@ -2,10 +2,7 @@
 import sys
 import os
 import re
-import urllib
-import urllib2
 import io
-import cStringIO
 import json
 from subprocess import *
 import subprocess
@@ -15,11 +12,16 @@ from BaseSpacePy.model import *
 from BaseSpacePy.api.BaseSpaceException import RestMethodException, ServerResponseException
 
 
+import six
+from six import moves
+from six.moves import urllib
+
+
 class APIClient:
     def __init__(self, AccessToken, apiServerAndVersion, userAgent=None, timeout=10):
         '''
         Initialize the API instance
-        
+
         :param AccessToken: an access token
         :param apiServerAndVersion: the URL of the BaseSpace api server with api version
         :param timeout: (optional) the timeout in seconds for each request made, default 10
@@ -32,7 +34,7 @@ class APIClient:
     def __forcePostCall__(self, resourcePath, postData, headers):
         '''
         For forcing a REST POST request (seems to be used when POSTing with no post data)
-                
+
         :param resourcePath: the url to call, including server address and api version
         :param postData: a dictionary of data to post
         :param headers: a dictionary of header key/values to include in call
@@ -46,7 +48,7 @@ class APIClient:
             pass
         import logging
         logging.getLogger("requests").setLevel(logging.WARNING)
-        encodedPost =  urllib.urlencode(postData)
+        encodedPost =  urllib.parse.urlencode(postData)
         resourcePath = "%s?%s" % (resourcePath, encodedPost)
         response = requests.post(resourcePath, data=json.dumps(postData), headers=headers)
         return response.text
@@ -54,9 +56,9 @@ class APIClient:
     def __putCall__(self, resourcePath, headers, data):
         '''
         Performs a REST PUT call to the API server.
-        
-        :param resourcePath: the url to call, including server address and api version        
-        :param headers: a dictionary of header key/values to include in call        
+
+        :param resourcePath: the url to call, including server address and api version
+        :param headers: a dictionary of header key/values to include in call
         :param transFile: the name of the file containing only data to be PUT
         :returns: server response (a string containing upload status message (from curl?) followed by json response)
         '''
@@ -64,7 +66,7 @@ class APIClient:
         # cmd = 'curl -H "x-access-token:' + self.apiKey + '" -H "Content-MD5:' + headers['Content-MD5'].strip() +'" -T "'+ transFile +'" -X PUT ' + resourcePath
         # p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=STDOUT, close_fds=True)
         # output = p.stdout.read()
-        # print output
+        # print(output)
         # return output
         import requests
         put_headers = {
@@ -79,12 +81,12 @@ class APIClient:
     def callAPI(self, resourcePath, method, queryParams, postData, headerParams=None, forcePost=False):
         '''
         Call a REST API and return the server response.
-        
+
         An access token header is automatically added.
         If a Content-Type header isn't included, one will be added with 'application/json' (except for PUT and forcePost calls).
         Query parameters with values of None aren't sent to the server.
         Server errors are to be handled by the caller (returned response contains error codes/msgs).
-        
+
         :param resourcePath: the url to call, not including server address and api version
         :param method: REST method, including GET, POST (and forcePost, see below), and PUT (DELETE not yet supported)
         :param queryParams: dictionary of query parameters to be added to url, except for forcePost where they are added as 'postData'; not used for PUT calls
@@ -101,41 +103,42 @@ class APIClient:
         if self.userAgent:
             headers['User-Agent'] = self.userAgent
         if headerParams:
-            for param, value in headerParams.iteritems():
+            for param, value in six.iteritems(headerParams):
                 headers[param] = value
         # specify the content type
-        if not headers.has_key('Content-Type') and not method=='PUT' and not forcePost: 
+        if not 'Content-Type' in headers and not method=='PUT' and not forcePost:
             headers['Content-Type'] = 'application/json'
-        # include access token in header 
+        # include access token in header
         headers['Authorization'] = 'Bearer ' + self.apiKey
-        
+
         data = None
         if method == 'GET':
             if queryParams:
                 # Need to remove None values, these should not be sent
                 sentQueryParams = {}
-                for param, value in queryParams.iteritems():
+                for param, value in six.iteritems(queryParams):
                     if value != None:
                         sentQueryParams[param] = value
-                url = url + '?' + urllib.urlencode(sentQueryParams)
-            request = urllib2.Request(url=url, headers=headers)
+                url = url + '?' + urllib.parse.urlencode(sentQueryParams)
+            request = urllib.request.Request(url=url, headers=headers)
         elif method in ['POST', 'PUT', 'DELETE']:
             if queryParams:
                 # Need to remove None values, these should not be sent
                 sentQueryParams = {}
-                for param, value in queryParams.iteritems():
+                for param, value in six.iteritems(queryParams):
                     if value != None:
                         sentQueryParams[param] = value
-                forcePostUrl = url 
-                url = url + '?' + urllib.urlencode(sentQueryParams)
+                forcePostUrl = url
+                url = url + '?' + urllib.parse.urlencode(sentQueryParams)
             data = postData
             if data:
                 if type(postData) not in [str, int, float, bool]:
                     data = json.dumps(postData)
             if not forcePost:
-                if data and not len(data): 
+                if data and not len(data):
                     data='\n' # temp fix, in case is no data in the file, to prevent post request from failing
-                request = urllib2.Request(url=url, headers=headers, data=data)#,timeout=self.timeout)
+                data = data.encode('utf-8')
+                request = urllib.request.Request(url=url, headers=headers, data=data)#,timeout=self.timeout)
             else:
                 response = self.__forcePostCall__(forcePostUrl, sentQueryParams, headers)
             if method in ['PUT', 'DELETE']:
@@ -149,49 +152,49 @@ class APIClient:
         # Make the request
         if not forcePost and not method in ['PUT', 'DELETE']: # the normal case
             try:
-             response = urllib2.urlopen(request, timeout=self.timeout).read()
-            except urllib2.HTTPError as e:                
-                response = e.read() # treat http error as a response (handle in caller)                
-            except urllib2.URLError as e:
-                raise ServerResponseException('URLError: ' + str(e))            
+             response = urllib.request.urlopen(request, timeout=self.timeout).read().decode('utf-8')
+            except urllib.error.HTTPError as e:
+                response = e.read() # treat http error as a response (handle in caller)
+            except urllib.error.URLError as e:
+                raise ServerResponseException('URLError: ' + str(e))
         try:
             data = json.loads(response)
         except ValueError as e:
             raise ServerResponseException('Error decoding json in server response')
-        return data            
+        return data
 
     def deserialize(self, obj, objClass):
         """
         Deserialize a JSON string into a BaseSpacePy object.
 
         :param obj: A dictionary (or object?) to be deserialized into a class (objClass); or a value to be passed into a new native python type (objClass)
-        :param objClass: A class object or native python type for the deserialized object, or a string of a class name or native python type. (eg, Project.Project, int, 'Project', 'int') 
+        :param objClass: A class object or native python type for the deserialized object, or a string of a class name or native python type. (eg, Project.Project, int, 'Project', 'int')
         :returns: A deserialized object
-        """        
+        """
         # Create an object class from objClass, if a string was passed in
         # Avoid native python types 'file'
-        if type(objClass) == str:            
+        if type(objClass) == str:
             try:
-                if (not str(objClass)=='File'): 
+                if (not str(objClass)=='File'):
                     objClass = eval(objClass.lower())
                 else:
                     objClass = eval(objClass + '.' + objClass)
             except NameError: # not a native type, must be model class
                 objClass = eval(objClass + '.' + objClass)
-        
+
         # Create an instance of the object class
-        # If the instance is a native python type, return it        
+        # If the instance is a native python type, return it
         if objClass in [str, int, float, bool]:
             return objClass(obj)
         instance = objClass()
-        
+
         # For every swaggerType in the instance that is also in the passed-in obj,
         # set the instance value for native python types,
         # or recursively deserialize class instances.
         # For dynamic types, substitute real class after looking up 'Type' value.
         # For lists, deserialize all members of a list, including lists of lists (though not list of list of list...).
-        # For datetimes, convert to a readable output string 
-        for attr, attrType in instance.swaggerTypes.iteritems():
+        # For datetimes, convert to a readable output string
+        for attr, attrType in six.iteritems(instance.swaggerTypes):
             if attr in obj:
                 value = obj[attr]
                 if attrType in ['str', 'int', 'float', 'bool']:
@@ -199,52 +202,52 @@ class APIClient:
                     try:
                         value = attrType(value)
                     except UnicodeEncodeError:
-                        value = unicode(value)
-                    setattr(instance, attr, value)                            
-                elif attrType == 'DynamicType':                                                
+                        value = six.text_type(value)
+                    setattr(instance, attr, value)
+                elif attrType == 'DynamicType':
                     try:
-                        model_name = instance._dynamicType[value['Type']]                
+                        model_name = instance._dynamicType[value['Type']]
                     except KeyError:
                         pass
                         # suppress this warning, which is caused by a bug in BaseSpace
-                        #warn("Warning - unrecognized dynamic type: " + value['Type'])                                                                                    
+                        #warn("Warning - unrecognized dynamic type: " + value['Type'])
                     else:
                         setattr(instance, attr, self.deserialize(value, model_name))
                 elif 'list<' in attrType:
                     match = re.match('list<(.*)>', attrType)
-                    subClass = match.group(1)                    
-                    subValues = []                       
+                    subClass = match.group(1)
+                    subValues = []
 
                     # lists of dynamic type
-                    if subClass == 'DynamicType':                             
-                        for subValue in value:                            
+                    if subClass == 'DynamicType':
+                        for subValue in value:
                             try:
-                                new_type = instance._dynamicType[subValue['Type']]                                
+                                new_type = instance._dynamicType[subValue['Type']]
                             except KeyError:
-                                pass 
+                                pass
                                 # suppress this warning, which is caused by a bug in BaseSpace
-                                #warn("Warning - unrecognized (list of) dynamic types: " + subValue['Type'])                                
+                                #warn("Warning - unrecognized (list of) dynamic types: " + subValue['Type'])
                             else:
-                                subValues.append(self.deserialize(subValue, new_type)) 
+                                subValues.append(self.deserialize(subValue, new_type))
                         setattr(instance, attr, subValues)
                     # typical lists
-                    else:                                                                             
+                    else:
                         for subValue in value:
                             subValues.append(self.deserialize(subValue, subClass))
                         setattr(instance, attr, subValues)
                 # list of lists (e.g. map[] property type)
                 elif 'listoflists<' in attrType:
                     match = re.match('listoflists<(.*)>', attrType)
-                    subClass = match.group(1)                    
-                    outvals = []                
+                    subClass = match.group(1)
+                    outvals = []
                     for outval in value:
                         invals = []
                         for inval in outval:
                             invals.append(self.deserialize(inval, subClass))
                         outvals.append(invals)
                     setattr(instance, attr, outvals)
-                                            
-                elif attrType=='dict':                                          
+
+                elif attrType=='dict':
                     setattr(instance, attr, value)
                 elif attrType=='datetime':
                     dt = dateutil.parser.parse(value)

--- a/src/BaseSpacePy/api/APIClient.py
+++ b/src/BaseSpacePy/api/APIClient.py
@@ -137,13 +137,14 @@ class APIClient:
             if not forcePost:
                 if data and not len(data):
                     data='\n' # temp fix, in case is no data in the file, to prevent post request from failing
-                data = data.encode('utf-8')
+                if isinstance(data, unicode):
+                    data = data.encode('utf-8')
                 request = urllib.request.Request(url=url, headers=headers, data=data)#,timeout=self.timeout)
             else:
                 response = self.__forcePostCall__(forcePostUrl, sentQueryParams, headers)
             if method in ['PUT', 'DELETE']:
                 if method == 'DELETE':
-                    raise NotImplementedError("DELETE REST API calls aren't currently supported")
+                    raise NotImplementedError('DELETE REST API calls aren\'t currently supported')
                 response = self.__putCall__(url, headers, data)
                 response =  response.split()[-1] # discard upload status msg (from curl put?)
         else:

--- a/src/BaseSpacePy/api/AppLaunchHelpers.py
+++ b/src/BaseSpacePy/api/AppLaunchHelpers.py
@@ -428,7 +428,7 @@ class LaunchSpecification(object):
             raise LaunchSpecificationException(
                 "Compulsory variable(s) missing! (%s)" % str(required_vars - supplied_var_names))
         if supplied_var_names - self.get_variable_requirements():
-            print "warning! unused variable(s) specified: (%s)" % str(supplied_var_names - self.get_variable_requirements())
+            print("warning! unused variable(s) specified: (%s)" % str(supplied_var_names - self.get_variable_requirements()))
         all_vars = copy.copy(self.defaults)
         all_vars.update(user_supplied_vars)
         self.resolve_list_variables(all_vars)
@@ -457,7 +457,7 @@ class LaunchSpecification(object):
         dump all properties with their type and any default value
         for verbose usage information output
         """
-        print self.format_property_information()
+        print(self.format_property_information())
 
     def format_minimum_requirements(self):
         minimum_requirements = self.get_minimum_requirements()

--- a/src/BaseSpacePy/api/AuthenticationAPI.py
+++ b/src/BaseSpacePy/api/AuthenticationAPI.py
@@ -1,6 +1,5 @@
 import sys
 import time
-import ConfigParser
 import getpass
 import os
 import requests
@@ -11,6 +10,14 @@ try:
 except:
     pass
 import logging
+
+import six
+
+from six.moves import input
+
+from six.moves import configparser
+
+
 logging.getLogger("requests").setLevel(logging.WARNING)
 
 __author__ = 'psaffrey'
@@ -47,9 +54,9 @@ class AuthenticationAPI(object):
         parses the config_path or creates it if it doesn't exist
 
         :param config_path: path to config file
-        :return: ConfigParser object
+        :return: configparser object
         """
-        self.config = ConfigParser.SafeConfigParser()
+        self.config = configparser.SafeConfigParser()
         self.config.optionxform = str
         if os.path.exists(self.config_path):
             self.config.read(self.config_path)
@@ -86,7 +93,8 @@ class SessionAuthentication(AuthenticationAPI):
         pass
 
     def set_session_details(self, config_path):
-        username = raw_input("username:")
+        inputfunc = raw_input if six.PY2 else input
+        username = inputfunc("username:")
         password = getpass.getpass()
         s, r = self.basespace_session(username, password)
         self.config.set(self.DEFAULT_CONFIG_NAME, self.SESSION_TOKEN_NAME, r.cookies[self.COOKIE_NAME])
@@ -129,7 +137,7 @@ class OAuthAuthentication(AuthenticationAPI):
                 raise AuthenticationException(msg)
         auth_url = payload["verification_with_code_uri"]
         auth_code = payload["device_code"]
-        print "please authenticate here: %s" % auth_url
+        print("please authenticate here: %s" % auth_url)
         # poll the token URL until we get the token
         token_payload = {
             "client_id": client_id,
@@ -156,6 +164,6 @@ class OAuthAuthentication(AuthenticationAPI):
         self.construct_default_config(self.api_server)
         if not access_token:
             raise Exception("problem obtaining token!")
-        print "Success!"
+        print("Success!")
         self.config.set(self.DEFAULT_CONFIG_NAME, self.ACCESS_TOKEN_NAME, access_token)
         self.write_config()

--- a/src/BaseSpacePy/api/BaseMountInterface.py
+++ b/src/BaseSpacePy/api/BaseMountInterface.py
@@ -74,12 +74,12 @@ class BaseMountInterface(object):
         return "%s : (%s) : (%s)" % (self.path, self.id, self.type)
 
     def _get_access_token_from_config(self, config_path):
-        from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
+        from configParser import SafeConfigParser, NoSectionError, NoOptionError
         config = SafeConfigParser()
         config.read(config_path)
         try:
             return config.get("DEFAULT", "accessToken")
-        except NoOptionError, NoSectionError:
+        except NoOptionError as NoSectionError:
             raise BaseMountInterfaceException("malformed BaseMount config: %s" % config_path)
 
 
@@ -105,4 +105,4 @@ if __name__ == "__main__":
     import sys
     path = sys.argv[1]
     mbi = BaseMountInterface(path)
-    print mbi
+    print(mbi)

--- a/src/BaseSpacePy/api/BaseSpaceAPI.py
+++ b/src/BaseSpacePy/api/BaseSpaceAPI.py
@@ -1309,11 +1309,8 @@ class BaseSpaceAPI(BaseAPI):
         :raises DownloadFailedException: if downloaded file size doesn't match the size in BaseSpace
         :returns: None
         '''
-        logging.debug("in __downloadFile__")
         if byteRange is None:
             byteRange = []
-        if byteRange is not None:
-            logging.debug("byteRange is not none!")
         resourcePath = '/files/{Id}/content'
         resourcePath = resourcePath.replace('{format}', 'json')
         method = 'GET'
@@ -1354,8 +1351,6 @@ class BaseSpaceAPI(BaseAPI):
         # check that actual downloaded byte size is correct
         if len(byteRange):
             expSize = byteRange[1] - byteRange[0] + 1
-            logging.debug("len is %d, first is %d, last is %d", len(byteRange), byteRange[0], byteRange[1])
-            logging.debug("totRead: %s, expSize: %s", totRead, expSize)
             if totRead != expSize:
                 raise DownloadFailedException("Ranged download size is not as expected: %d vs %d" % (totRead, expSize))
         else:

--- a/src/BaseSpacePy/api/BaseSpaceAPI.py
+++ b/src/BaseSpacePy/api/BaseSpaceAPI.py
@@ -1309,8 +1309,11 @@ class BaseSpaceAPI(BaseAPI):
         :raises DownloadFailedException: if downloaded file size doesn't match the size in BaseSpace
         :returns: None
         '''
+        logging.debug("in __downloadFile__")
         if byteRange is None:
             byteRange = []
+        if byteRange is not None:
+            logging.debug("byteRange is not none!")
         resourcePath = '/files/{Id}/content'
         resourcePath = resourcePath.replace('{format}', 'json')
         method = 'GET'
@@ -1351,6 +1354,8 @@ class BaseSpaceAPI(BaseAPI):
         # check that actual downloaded byte size is correct
         if len(byteRange):
             expSize = byteRange[1] - byteRange[0] + 1
+            logging.debug("len is %d, first is %d, last is %d", len(byteRange), byteRange[0], byteRange[1])
+            logging.debug("totRead: %s, expSize: %s", totRead, expSize)
             if totRead != expSize:
                 raise DownloadFailedException("Ranged download size is not as expected: %d vs %d" % (totRead, expSize))
         else:

--- a/src/BaseSpacePy/api/BaseSpaceException.py
+++ b/src/BaseSpacePy/api/BaseSpaceException.py
@@ -16,31 +16,31 @@ class IllegalParameterException(Exception):
         self.parameter = str(value) + ' is not well-defined, legal options are ' + str(legal)
     def __str__(self):
         return repr(self.parameter)
-    
+
 class WrongFiletypeException(Exception):
     def __init__(self, filetype):
         self.parameter = 'This data request is not available for file ' + str(filetype)
     def __str__(self):
         return repr(self.parameter)
-    
+
 class ServerResponseException(Exception):
     def __init__(self, value):
         self.parameter = 'Error with API server response: ' + value
     def __str__(self):
         return repr(self.parameter)
-    
+
 class ModelNotInitializedException(Exception):
     def __init__(self,value):
         self.parameter = 'The request cannot be completed as model has not been initialized - ' + value
     def __str__(self):
         return repr(self.parameter)
-    
+
 class ByteRangeException(Exception):
     def __init__(self, value):
         self.parameter = 'Byte-range invalid: ' + value
     def __str__(self):
         return repr(self.parameter)
-    
+
 class MultiProcessingTaskFailedException(Exception):
     def __init__(self, value):
         self.parameter = 'Multiprocessing task failed: ' + value
@@ -88,4 +88,9 @@ class RestMethodException(Exception):
         self.parameter = 'Problem with REST API method: ' + value
     def __str__(self):
         return repr(self.parameter)
-    
+
+class DownloadFailedException(Exception):
+    def __init__(self, value):
+        self.parameter = 'Download failed: ' + value
+    def __str__(self):
+        return repr(self.parameter)

--- a/src/BaseSpacePy/api/BillingAPI.py
+++ b/src/BaseSpacePy/api/BillingAPI.py
@@ -1,9 +1,11 @@
 
-import urlparse
 from BaseSpacePy.api.BaseAPI import BaseAPI
 from BaseSpacePy.api.BaseSpaceException import * #@UnusedWildImport
 from BaseSpacePy.model import * #@UnusedWildImport
 from BaseSpacePy.model.QueryParametersPurchasedProduct import QueryParametersPurchasedProduct as qpp
+
+from six.moves import urllib
+
 
 class BillingAPI(BaseAPI):
     '''
@@ -18,7 +20,7 @@ class BillingAPI(BaseAPI):
         '''        
         self.appSessionId   = appSessionId        
         self.version        = version        
-        apiServerAndVersion = urlparse.urljoin(apiServer, version)        
+        apiServerAndVersion = urllib.parse.urljoin(apiServer, version)        
         super(BillingAPI, self).__init__(AccessToken, apiServerAndVersion)
 
     def createPurchase(self, products, appSessionId=''):

--- a/src/BaseSpacePy/model/ListResponse.py
+++ b/src/BaseSpacePy/model/ListResponse.py
@@ -1,6 +1,8 @@
 
 import json
-from StringIO import StringIO
+
+from six import StringIO
+
 
 class ListResponse(object):
 

--- a/src/BaseSpacePy/model/MultipartFileTransfer.py
+++ b/src/BaseSpacePy/model/MultipartFileTransfer.py
@@ -3,7 +3,6 @@ import time
 import os
 import math
 import multiprocessing
-import Queue
 import shutil
 import signal
 import hashlib
@@ -11,31 +10,35 @@ from subprocess import call
 import logging
 from BaseSpacePy.api.BaseSpaceException import MultiProcessingTaskFailedException
 
+from six.moves import queue
+from six.moves import range
+
+
 LOGGER = logging.getLogger(__name__)
 
 
 class UploadTask(object):
     '''
-    Uploads a piece of a large local file.    
-    '''    
+    Uploads a piece of a large local file.
+    '''
     def __init__(self, api, bs_file_id, piece, total_pieces, local_path, total_size, chunk_size):
         self.api        = api
         self.bs_file_id = bs_file_id  # the BaseSpace File Id
-        self.piece      = piece       # piece number 
+        self.piece      = piece       # piece number
         self.total_pieces = total_pieces # out of total piece count
-        self.local_path = local_path  # the path of the local file to be uploaded, including file name        
+        self.local_path = local_path  # the path of the local file to be uploaded, including file name
         self.total_size = total_size  # total file size of upload, for reporting
         self.chunk_size   = chunk_size    # chunk size
-        
+
         # tasks must implement these attributes and execute()
         self.success  = False
-        self.err_msg = "no error"      
-    
+        self.err_msg = "no error"
+
     def execute(self, lock):
         '''
         Calculate md5 of file piece and pass to upload method.
         Lock is not used (but needed since worker sends it for multipart download)
-        '''            
+        '''
         try:
             fname = os.path.basename(self.local_path)
             chunk_data = ""
@@ -47,10 +50,10 @@ class UploadTask(object):
                 res = self.api.__uploadMultipartUnit__(self.bs_file_id,self.piece+1,self.md5,chunk_data)
             except Exception as e:
                 self.success = False
-                self.err_msg = str(e)                
+                self.err_msg = str(e)
             else:
                 # ETag contains hex encoded MD5 of part data on success
-                if res and res['Response'].has_key('ETag'):                
+                if res and 'ETag' in res['Response']:                
                     self.success = True
                 else:
                     self.success = False
@@ -60,7 +63,7 @@ class UploadTask(object):
             self.success = False
             self.err_msg = str(e)
         return self
-        
+
     def __str__(self):
         return 'File piece %d of %d, total %s' % (self.piece+1, self.total_pieces, Utils.readable_bytes(self.total_size))
 
@@ -69,7 +72,7 @@ class DownloadTask(object):
     '''
     Downloads a piece of a large remote file.
     When temp_dir is set (debug mode), downloads to filename with piece number appended (i.e. temp file).
-    '''    
+    '''
     def __init__(self, api, bs_file_id, file_name, local_dir, piece, total_pieces, part_size, total_size, temp_dir=None):
         self.api = api                # BaseSpace api object
         self.bs_file_id = bs_file_id  # the Id of the File in BaseSpace
@@ -78,13 +81,13 @@ class DownloadTask(object):
         self.total_pieces = total_pieces # total pieces being downloaded (for reporting only)
         self.part_size = part_size    # the size in bytes (not MB) of each piece (except last piece)
         self.total_size  = total_size # the total size of the file in bytes
-        self.local_dir = local_dir    # the path in which to store the downloaded file        
-        self.temp_dir = temp_dir      # optional: set temp_dir for debug mode, which writes downloaded chunks to individual temp files         
-        
+        self.local_dir = local_dir    # the path in which to store the downloaded file
+        self.temp_dir = temp_dir      # optional: set temp_dir for debug mode, which writes downloaded chunks to individual temp files
+
         # tasks must implement these attributes and execute()
         self.success  = False
-        self.err_msg = "no error"         
-    
+        self.err_msg = "no error"
+
     def execute(self, lock):
         '''
         Download a piece of the target file, first calculating start/end bytes for piece.
@@ -104,147 +107,147 @@ class DownloadTask(object):
             startbyte = (self.piece - 1) * self.part_size
             endbyte = (self.piece * self.part_size) - 1
             if endbyte > self.total_size:
-                endbyte = self.total_size - 1            
-            try:                
+                endbyte = self.total_size - 1
+            try:
                 #self.api.__downloadFile__(self.bs_file_id, self.local_dir, transFile, [startbyte, endbyte], standaloneRangeFile, lock)
-                self.api.__downloadFile__(self.bs_file_id, local_dir, local_name, [startbyte, endbyte], standaloneRangeFile, lock)                                
+                self.api.__downloadFile__(self.bs_file_id, local_dir, local_name, [startbyte, endbyte], standaloneRangeFile, lock)
             except Exception as e:
                 self.success = False
-                self.err_msg = str(e)                
-            else:                
+                self.err_msg = str(e)
+            else:
                 self.success = True
         # capture exception, since unpickleable exceptions may block
         except Exception as e:
             self.success = False
             self.err_msg = str(e)
         return self
-        
-    def __str__(self):                
+
+    def __str__(self):
         return 'File piece %d of %d, piece size %s of total %s' % (self.piece, self.total_pieces, Utils.readable_bytes(self.part_size), Utils.readable_bytes(self.total_size))
-    
+
 class Consumer(multiprocessing.Process):
     '''
     Multi-processing worker that executes tasks from task queue with retry
     On failure after retries, alerts all workers to halt
     '''
-    
-    def __init__(self, task_queue, result_queue, halt_event, lock):    
+
+    def __init__(self, task_queue, result_queue, halt_event, lock):
         multiprocessing.Process.__init__(self)
         self.task_queue = task_queue
-        self.result_queue = result_queue        
+        self.result_queue = result_queue
         self.halt = halt_event
-        self.lock = lock         
-        
+        self.lock = lock
+
         self.get_task_timeout = 5 # secs
         self.retry_wait = 1 # sec
         self.retries = 20
-        
+
     def run(self):
         '''
-        Executes tasks from the task queue until poison pill is reached, halt 
+        Executes tasks from the task queue until poison pill is reached, halt
         signal is found, or something went wrong such as a timeout when getting
-        new tasks. 
-        
+        new tasks.
+
         For download tasks, use lock to ensure sole access (among worker
         processes) to downloaded file.
-        
+
         Retries failed tasks, and add task results to result_queue.
         When a task fails for all retries, set halt signal to alert other workers
         and purge task queue or remaining tasks (to unblock join() in parent process)
-        
+
         Turn off SIGINT (Ctrl C), handle in parent process
         '''
         signal.signal(signal.SIGINT, signal.SIG_IGN)
-        while True:                                
+        while True:
             try:
                 next_task = self.task_queue.get(True, self.get_task_timeout) # block until timeout
-            except Queue.Empty:
+            except queue.Empty:
                 LOGGER.debug('Worker %s exiting, getting task from task queue timed out and/or is empty' % self.name)
-                break                    
-            if next_task is None:            
+                break
+            if next_task is None:
                 LOGGER.debug('Worker %s exiting, found final task' % self.name)
                 self.task_queue.task_done()
-                break                                                                   
-            else:                                                       
+                break
+            else:
                 # attempt to run tasks, with retry
                 LOGGER.debug('Worker %s processing task: %s' % (self.name, str(next_task)))
                 LOGGER.info('%s' % str(next_task))
-                for i in xrange(1, self.retries + 1):
+                for i in range(1, self.retries + 1):
                     if self.halt.is_set():
                         LOGGER.debug('Worker %s exiting, found halt signal' % self.name)
                         self.task_queue.task_done()
                         self.purge_task_queue()
-                        return                                                            
-                    answer = next_task.execute(self.lock) # acquired lock will block other workers                                       
+                        return
+                    answer = next_task.execute(self.lock) # acquired lock will block other workers
                     if answer.success == True:
-                        self.task_queue.task_done()                   
+                        self.task_queue.task_done()
                         self.result_queue.put(True)
                         break
                     else:
                         LOGGER.debug("Worker %s retrying task %s after failure, retry attempt %d, with error msg: %s" % (self.name, str(next_task), i, answer.err_msg))
-                        time.sleep(self.retry_wait)                    
+                        time.sleep(self.retry_wait)
                 if not answer.success == True:
                     LOGGER.debug("Worker %s exiting, too many failures with retry for worker %s" % (self.name, str(self)))
-                    LOGGER.warning("Task failed after too many retries")        
-                    self.task_queue.task_done()                   
+                    LOGGER.warning("Task failed after too many retries")
+                    self.task_queue.task_done()
                     self.result_queue.put(False)
-                    self.purge_task_queue() # purge task queue in case there's only one worker                    
+                    self.purge_task_queue() # purge task queue in case there's only one worker
                     self.halt.set()
-                    break        
+                    break
         return
-    
+
     def purge_task_queue(self):
         '''
         Purge all remaining tasks from task queue. This will also remove poison pills
         (final tasks), so run() must handle an empty queue (by using a timeout with
         task_queue.get() ).
-        '''        
+        '''
         LOGGER.debug("Purging task queue")
         while 1:
             try:
-                self.task_queue.get(False)                
-            except Queue.Empty:            
+                self.task_queue.get(False)
+            except queue.Empty:
                 break
             else:
                 self.task_queue.task_done()
-                
+
 class Executor(object):
     '''
     Multi-processing task manager, with callback to finalize once workers are completed.
     Task queue contains tasks, with poison pill for each worker.
     Result queue contains True/False results for task success/failure.
     Halt event will tell workers to halt themselves.
-    
-    For downloads, lock is to ensure that only one worker writes to a local downloaded file at a time. 
+
+    For downloads, lock is to ensure that only one worker writes to a local downloaded file at a time.
     '''
-    def __init__(self):                                        
+    def __init__(self):
         self.tasks = multiprocessing.JoinableQueue()
         self.result_queue = multiprocessing.Queue()
         self.halt_event = multiprocessing.Event()
         self.lock = multiprocessing.Lock()
-    
+
     def add_task(self, task):
         '''
         Add task to task queue
         '''
-        self.tasks.put(task)        
-    
+        self.tasks.put(task)
+
     def add_workers(self, num_workers):
         '''
         Added workers to internal list of workers, adding a poison pill for each to the task queue
         '''
-        self.consumers = [ Consumer(self.tasks, self.result_queue, self.halt_event, self.lock) for i in xrange(num_workers) ]
+        self.consumers = [ Consumer(self.tasks, self.result_queue, self.halt_event, self.lock) for i in range(num_workers) ]
         for c in self.consumers:
             self.tasks.put(None)
 
     def start_workers(self, finalize_callback):
         '''
         Start workers, wait until workers finish, then call finalize callback if all went well
-        '''        
+        '''
         # TODO add failure callback for cleanup?
         for w in self.consumers:
-            w.start()        
-        LOGGER.debug("Workers started")                
+            w.start()
+        LOGGER.debug("Workers started")
         try:
             self.tasks.join()
         except (KeyboardInterrupt, SystemExit):
@@ -252,39 +255,39 @@ class Executor(object):
             self.result_queue.put(False)
             self.halt_event.set()
             self.tasks.join() # wait for workers to finish current work then exit from response to halt signal
-        else:                        
-            LOGGER.debug("Workers finished - task queue joined")                                   
+        else:
+            LOGGER.debug("Workers finished - task queue joined")
         finalize = True
         while 1:
             try:
-                success = self.result_queue.get(False) # non-blocking                    
-            except Queue.Empty:                    
+                success = self.result_queue.get(False) # non-blocking
+            except queue.Empty:
                 break
-            else:                    
-                if success == False:                        
+            else:
+                if success == False:
                     LOGGER.debug("Found a failed or cancelled task -- won't call finalize callback")
-                    finalize = False                                            
-        if finalize == True:                              
+                    finalize = False
+        if finalize == True:
             finalize_callback()
-        else:            
-            raise MultiProcessingTaskFailedException("Multiprocessing task did not complete successfully")                                                 
+        else:
+            raise MultiProcessingTaskFailedException("Multiprocessing task did not complete successfully")
 
 class MultipartUpload(object):
     '''
-    Uploads a (large) file by uploading file parts in separate processes.    
+    Uploads a (large) file by uploading file parts in separate processes.
     '''
     def __init__(self, api, local_path, bs_file, process_count, part_size, logger=None):
         '''
         Create a multipart upload object
-        
-        :param api:           the BaseSpace API object        
+
+        :param api:           the BaseSpace API object
         :param local_path:    the path of the local file, including file name
-        :param bs_file:       the File object of the newly created BaseSpace File to upload 
+        :param bs_file:       the File object of the newly created BaseSpace File to upload
         :param process_count: the number of process to use for uploading
-        :param part_size:     in MB, the size of each uploaded part        
+        :param part_size:     in MB, the size of each uploaded part
         '''
-        self.api            = api    
-        self.local_path     = local_path    
+        self.api            = api
+        self.local_path     = local_path
         self.remote_file    = bs_file
         self.process_count  = process_count
         self.part_size      = part_size
@@ -297,13 +300,13 @@ class MultipartUpload(object):
         BaseSpace that has updated (completed) attributes.
         '''
         self._setup()
-        self._start_workers()        
-        return self.api.getFileById(self.remote_file.Id)                        
-    
-    def _setup(self):        
+        self._start_workers()
+        return self.api.getFileById(self.remote_file.Id)
+
+    def _setup(self):
         '''
-        Determine number of file pieces to upload, add upload tasks to work queue         
-        '''                
+        Determine number of file pieces to upload, add upload tasks to work queue
+        '''
         from math import ceil
         total_size = os.path.getsize(self.local_path)
         # round up to get a number of chunks that will be enough for the whole file
@@ -323,12 +326,12 @@ class MultipartUpload(object):
         #     err_msg = "Splitting local file failed: %s" % self.local_path
         #     raise MultiProcessingTaskFailedException(err_msg)
 
-        self.exe = Executor()                    
-        for i in xrange(self.start_chunk, fileCount):
+        self.exe = Executor()
+        for i in range(self.start_chunk, fileCount):
             t = UploadTask(self.api, self.remote_file.Id, i, fileCount, self.local_path, total_size, chunk_size)
-            self.exe.add_task(t)            
+            self.exe.add_task(t)
         self.exe.add_workers(self.process_count)
-        self.task_total = fileCount - self.start_chunk + 1                                                
+        self.task_total = fileCount - self.start_chunk + 1
 
         LOGGER.info("Total File Size %s" % Utils.readable_bytes(total_size))
         LOGGER.info("Using File Part Size %d MB" % self.part_size)
@@ -339,15 +342,15 @@ class MultipartUpload(object):
     def _start_workers(self):
         '''
         Start upload workers, register finalize callback method
-        '''                
-        finalize_callback = self._finalize_upload # lambda: None            
+        '''
+        finalize_callback = self._finalize_upload # lambda: None
         self.exe.start_workers(finalize_callback)
-    
+
     def _finalize_upload(self):
         '''
         Set file upload status as complete in BaseSpace
         '''
-        LOGGER.debug("Marking uploaded file status as complete")                                                   
+        LOGGER.debug("Marking uploaded file status as complete")
         self.api.__finalizeMultipartFileUpload__(self.remote_file.Id)
 
 class MultipartDownload(object):
@@ -359,105 +362,105 @@ class MultipartDownload(object):
     def __init__(self, api, file_id, local_dir, process_count, part_size, create_bs_dir, temp_dir=""):
         '''
         Create a multipart download object
-        
+
         :param api:           the BaseSpace API object
         :param file_id:       the BaseSpace File Id of the file to download
         :param local_dir:     the local directory in which to store the downloaded file
         :param process_count: the number of process to use for downloading
-        :param part_size:     in MB, the size of each file part to download        
+        :param part_size:     in MB, the size of each file part to download
         :param create_bs_dir: when True, create BaseSpace File's directory in local_dir; when False, ignore Bs directory
-        :param temp_dir:      (optional) temp directory for debug mode        
+        :param temp_dir:      (optional) temp directory for debug mode
         '''
-        self.api            = api            
-        self.file_id        = file_id         
-        self.local_dir      = local_dir               
-        self.process_count  = process_count  
-        self.part_size      = part_size              
+        self.api            = api
+        self.file_id        = file_id
+        self.local_dir      = local_dir
+        self.process_count  = process_count
+        self.part_size      = part_size
         self.temp_dir       = temp_dir
-        self.create_bs_dir  = create_bs_dir        
+        self.create_bs_dir  = create_bs_dir
 
-        self.start_chunk      = 1        
+        self.start_chunk      = 1
         self.partial_file_ext = ".partial"
-    
+
     def download(self):
         '''
         Start the download
         '''
         self._setup()
         self._start_workers()
-        return self.bs_file                
-        
+        return self.bs_file
+
     def _setup(self):
         '''
         Determine number of file pieces to download, determine full local path
         in which to download file, add download tasks to work queue.
-        
-        While download is in progress, name the file with a 'partial' extension 
+
+        While download is in progress, name the file with a 'partial' extension
         '''
         self.bs_file = self.api.getFileById(self.file_id)
         self.file_name = self.bs_file.Name
         total_bytes = self.bs_file.Size
         part_size_bytes = self.part_size * (1024**2)
         self.file_count = int(math.ceil(total_bytes/part_size_bytes)) + 1
-        
+
         file_name = self.file_name
         if not self.temp_dir:
             file_name = self.file_name + self.partial_file_ext
 
         self.full_local_dir = self.local_dir
         self.full_temp_dir = self.temp_dir
-        if self.create_bs_dir:            
-            self.full_local_dir = os.path.join(self.local_dir, os.path.dirname(self.bs_file.Path))            
+        if self.create_bs_dir:
+            self.full_local_dir = os.path.join(self.local_dir, os.path.dirname(self.bs_file.Path))
             if not os.path.exists(self.full_local_dir):
                 os.makedirs(self.full_local_dir)
             if self.temp_dir:
                 self.full_temp_dir = os.path.join(self.temp_dir, os.path.dirname(self.bs_file.Path))
                 if not os.path.exists(self.full_temp_dir):
                     os.makedirs(self.full_temp_dir)
-        
-        self.exe = Executor()                    
-        for i in xrange(self.start_chunk, self.file_count+1):         
-            t = DownloadTask(self.api, self.file_id, file_name, self.full_local_dir, 
+
+        self.exe = Executor()
+        for i in range(self.start_chunk, self.file_count+1):
+            t = DownloadTask(self.api, self.file_id, file_name, self.full_local_dir,
                              i, self.file_count, part_size_bytes, total_bytes, self.full_temp_dir)
-            self.exe.add_task(t)            
-        self.exe.add_workers(self.process_count)        
-        self.task_total = self.file_count - self.start_chunk + 1                                                
-                                 
+            self.exe.add_task(t)
+        self.exe.add_workers(self.process_count)
+        self.task_total = self.file_count - self.start_chunk + 1
+
         LOGGER.debug("Total File Size %s" % Utils.readable_bytes(total_bytes))
         LOGGER.debug("Using File Part Size %s MB" % str(self.part_size))
         LOGGER.debug("Processes %d" % self.process_count)
         LOGGER.debug("File Chunk Count %d" % self.file_count)
         LOGGER.debug("Start Chunk %d" % self.start_chunk)
-                            
+
     def _start_workers(self):
         '''
         Start download workers, register finalize callback method
-        '''        
+        '''
         if self.temp_dir:
             finalize_callback = self._combine_file_chunks
         else:
-            finalize_callback = self._rename_final_file # lambda: None            
-        self.exe.start_workers(finalize_callback)                        
-    
+            finalize_callback = self._rename_final_file # lambda: None
+        self.exe.start_workers(finalize_callback)
+
     def _rename_final_file(self):
         '''
         Remove the 'partial' extension from the downloaded file
         '''
         final_file = os.path.join(self.full_local_dir, self.file_name)
         partial_file = final_file + self.partial_file_ext
-        os.rename(partial_file, final_file) 
-    
+        os.rename(partial_file, final_file)
+
     def _combine_file_chunks(self):
         '''
         Assembles download files chunks into single large file, then cleanup by deleting file chunks
-        '''        
-        LOGGER.debug("Assembling downloaded file parts into single file")                                                   
-        part_files = [os.path.join(self.full_temp_dir, self.file_name + '.' + str(i)) for i in xrange(self.start_chunk, self.file_count+1)]                    
+        '''
+        LOGGER.debug("Assembling downloaded file parts into single file")
+        part_files = [os.path.join(self.full_temp_dir, self.file_name + '.' + str(i)) for i in range(self.start_chunk, self.file_count+1)]
         with open(os.path.join(self.full_local_dir, self.file_name), 'w+b') as whole_file:
-            for part_file in part_files:                
-                shutil.copyfileobj(open(part_file, 'r+b'), whole_file)                         
+            for part_file in part_files:
+                shutil.copyfileobj(open(part_file, 'r+b'), whole_file)
         for part_file in part_files:
-            os.remove(part_file)                        
+            os.remove(part_file)
 
 class Utils(object):
     '''
@@ -475,7 +478,7 @@ class Utils(object):
                 break
             md5.update(data)
         return md5.hexdigest()
-    
+
     @staticmethod
     def readable_bytes(size, precision=2):
         """
@@ -487,4 +490,3 @@ class Utils(object):
             suffixIndex += 1 # increment the index of the suffix
             size = size / 1024.0 # apply the division
         return "%.*f %s" % (precision, size, suffixes[suffixIndex])
-        

--- a/src/BaseSpacePy/model/QueryParameters.py
+++ b/src/BaseSpacePy/model/QueryParameters.py
@@ -1,4 +1,4 @@
-
+import six
 from BaseSpacePy.api.BaseSpaceException import UndefinedParameterException, UnknownParameterException, IllegalParameterException, QueryParameterException
 
 legal = {'Statuses': [],
@@ -8,66 +8,66 @@ legal = {'Statuses': [],
          #'Extensions': ['bam', 'vcf'],
          'Offset': [],
          'Limit': [],
-         'SortDir': ['Asc', 'Desc'], 
-         'Name': [], 
-         'StartPos':[], 
-         'EndPos':[], 
+         'SortDir': ['Asc', 'Desc'],
+         'Name': [],
+         'StartPos':[],
+         'EndPos':[],
          'Format':[],
          'include':[],
          'propertyFilters':[],
          'userCreatedBy':[]
-         #'Format': ['txt', 'json', 'vcf'], 
+         #'Format': ['txt', 'json', 'vcf'],
          }
 
 class QueryParameters(object):
     '''
     The QueryParameters class can be passed as an optional argument
-    for sorting/filtering of list-responses (such as lists of samples, AppResults, variants, etc.)    
+    for sorting/filtering of list-responses (such as lists of samples, AppResults, variants, etc.)
     '''
     def __init__(self, pars=None, required=None):
         '''
         :param pars: (optional) a dictionary of query parameters, default None
         :param required: (optional) a list of required query parameter names, default None
-        
+
         :raises QueryParameterException: when non-dictionary argument for 'pars' is passed
         '''
         if pars is None:
             pars = {}
         if required is None:
-            required = []         
+            required = []
         self.passed = {}
         try:
-            for k in pars.keys():
+            for k in six.viewkeys(pars):
                 self.passed[k] = pars[k]
         except AttributeError:
             raise QueryParameterException("The 'pars' argument to QueryParameters must be a dictionary")
         self.required = required
-        
+
     def __str__(self):
         return str(self.passed)
-    
+
     def __repr__(self):
         return str(self)
-    
+
     def getParameterDict(self):
         return self.passed
-    
+
     def validate(self):
         '''
         Validates that query parameter keys and values are properly formed:
-        required keys are present, and keys and values are within the set of 
+        required keys are present, and keys and values are within the set of
         known acceptable keys/values.
-        
+
         :raises UndefinedParameterException: when a required parameter is not present
         :raises UnknownParameterException: when a parameter name is not present in the list of acceptable parameters names
         :raises IllegalParameterException: when a parameter value (with a valid name) is not present in the list of acceptable parameters values
         :returns: None
         '''
         for p in self.required:
-            if not self.passed.has_key(p): 
+            if not p in self.passed:
                 raise UndefinedParameterException(p)
-        for p in self.passed.keys():
-            if not legal.has_key(p): 
+        for p in six.viewkeys(self.passed):
+            if not p in legal:
                 raise UnknownParameterException(p)
-            if len(legal[p])>0 and (not self.passed[p] in legal[p]): 
+            if len(legal[p])>0 and (not self.passed[p] in legal[p]):
                 raise IllegalParameterException(p,legal[p])

--- a/src/BaseSpacePy/model/QueryParametersPurchasedProduct.py
+++ b/src/BaseSpacePy/model/QueryParametersPurchasedProduct.py
@@ -1,4 +1,4 @@
-
+import six
 from BaseSpacePy.api.BaseSpaceException import UndefinedParameterException,UnknownParameterException,IllegalParameterException
 
 legal    = { 'Tags':[], 'ProductIds':[] }
@@ -11,20 +11,20 @@ class QueryParametersPurchasedProduct(object):
         if pars is None:
             pars = {}
         self.passed = {}
-        for k in pars.keys():
+        for k in six.viewkeys(pars):
             self.passed[k] = pars[k]
         self.validate()
-        
+
     def __str__(self):
         return str(self.passed)
-    
+
     def __repr__(self):
         return str(self)
-    
+
     def getParameterDict(self):
         return self.passed
-    
+
     def validate(self):
-        for p in self.passed.keys():
-            if not legal.has_key(p): 
+        for p in six.viewkeys(self.passed):
+            if not p in legal:
                 raise UnknownParameterException(p)

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ Copyright 2012 Illumina
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
     Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ except ImportError:
 setup(name='basespace-python-sdk',
       description='A Python SDK for connecting to Illumina BaseSpace data',
       author='Illumina',
-      version='0.4',
+      version='0.5',
       long_description="""
 BaseSpacePy is a Python based SDK to be used in the development of Apps and scripts for working with
 Illumina's BaseSpace cloud-computing solution for next-gen sequencing data analysis.
@@ -33,7 +33,7 @@ to authenticate a user, retrieve data, and upload data/results from their own an
       author_email='techsupport@illumina.com',
       packages=['BaseSpacePy.api','BaseSpacePy.model','BaseSpacePy'],
       package_dir={'BaseSpacePy' : os.path.join(os.path.dirname(__file__),'BaseSpacePy')},
-      install_requires=['python-dateutil','requests'],
+      install_requires=['python-dateutil','requests','six'],
       zip_safe=False,
 )
 
@@ -42,5 +42,4 @@ to authenticate a user, retrieve data, and upload data/results from their own an
 #try:
 #    import dateutil
 #except:
-#    print "WARNING - please install required package 'python-dateutil'"
-
+#    print("WARNING - please install required package 'python-dateutil'")

--- a/test/dotbasespace/completion.bash
+++ b/test/dotbasespace/completion.bash
@@ -1,0 +1,83 @@
+_bs()
+{
+  local cur prev words
+  IFS=$'\n'
+  COMPREPLY=()
+  _get_comp_words_by_ref -n : cur prev words
+
+  # Command data:
+  cmds=$'app\nappsession\nauth\nauthenticate\ncomplete\ncp\ncreate\nhelp\nhistory\nimport\nkill\nlaunch\nlist\nmount\nproject\nregister\nsample\nunmount\nunregister\nupload\nversion\nwhoami'
+  cmds_app=$'import launch'
+  cmds_app_import=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-i\n--appid\n-n\n--appname\n-p\n--properties-file\n-e\n--defaults-file\n-a\n--appsession-id\n-r\n--appversion\n-m\n--appsession-path\n-j\n--input-templates\n-f\n--force'
+  cmds_app_launch=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-i\n--appid\n-a\n--agentid\n-b\n--batch-size\n-n\n--appname\n-o\n--option\n-s\n--sample-attributes\n--disable-consistency-checking'
+  cmds_appsession=$'kill'
+  cmds_appsession_kill=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse'
+  cmds_auth=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n--api-server\n--api-version\n--force\n--scopes\n--client-id\n--client-secret'
+  cmds_authenticate=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n--api-server\n--api-version\n--force\n--scopes\n--client-id\n--client-secret'
+  cmds_complete=$'-h\n--help\n--name\n--shell'
+  cmds_cp=$'-h\n--help'
+  cmds_create=$'project'
+  cmds_create_project=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse'
+  cmds_help=$'-h\n--help'
+  cmds_history=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n--json\n--domain'
+  cmds_import=$'app'
+  cmds_import_app=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-i\n--appid\n-n\n--appname\n-p\n--properties-file\n-e\n--defaults-file\n-a\n--appsession-id\n-r\n--appversion\n-m\n--appsession-path\n-j\n--input-templates\n-f\n--force'
+  cmds_kill=$'appsession'
+  cmds_kill_appsession=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse'
+  cmds_launch=$'app'
+  cmds_launch_app=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-i\n--appid\n-a\n--agentid\n-b\n--batch-size\n-n\n--appname\n-o\n--option\n-s\n--sample-attributes\n--disable-consistency-checking'
+  cmds_mount=$'-h\n--help'
+  cmds_project=$'create'
+  cmds_project_create=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse'
+  cmds_register=$'-h\n--help\n-p\n--path\n-d\n--description\n-g\n--group\n--force'
+  cmds_sample=$'upload'
+  cmds_sample_upload=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-p\n--project\n-i\n--sample-id\n-e\n--experiment\n--show-validation-rules'
+  cmds_unmount=$'-h\n--help'
+  cmds_unregister=$'-h\n--help\n-g\n--group'
+  cmds_upload=$'sample'
+  cmds_upload_sample=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-p\n--project\n-i\n--sample-id\n-e\n--experiment\n--show-validation-rules'
+  cmds_version=$'-h\n--help'
+  cmds_list=$'samples\nprojects\nappsessions\nappresults\napps'
+  cmds_list_samples=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-f\n--format\n-C\n--column\n--max-width\n--noindent\n--quote\n--project-name'
+  cmds_list_projects=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-f\n--format\n-C\n--column\n--max-width\n--noindent\n--quote\n--project-name'
+  cmds_list_appsessions=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-f\n--format\n-C\n--column\n--max-width\n--noindent\n--quote\n--project-name'
+  cmds_list_appresults=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-f\n--format\n-C\n--column\n--max-width\n--noindent\n--quote\n--project-name'
+  cmds_list_apps=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-f\n--format\n-C\n--column\n--max-width\n--noindent\n--quote\n--project-name'
+  cmds_whoami=$'-v\n--verbose\n--log-file\n-q\n--quiet\n-h\n--help\n--debug\n-V\n--version\n--dry-run\n-c\n--config\n--terse\n-f\n--format\n-C\n--column\n--max-width\n--noindent\n--quote'
+
+  cmd=""
+  words[0]=""
+  completed="${cmds}"
+  for var in "${words[@]:1}"
+  do
+    if [[ ${var} == -* ]] ; then
+      break
+    fi
+    if [ -z "${cmd}" ] ; then
+      proposed="${var}"
+    else
+      proposed="${cmd}_${var}"
+    fi
+    local i="cmds_${proposed}"
+    local comp="${!i}"
+    if [ -z "${comp}" ] ; then
+      break
+    fi
+    if [[ ${comp} == -* ]] ; then
+      if [[ ${cur} != -* ]] ; then
+        completed=""
+        break
+      fi
+    fi
+    cmd="${proposed}"
+    completed="${comp}"
+  done
+
+  if [ -z "${completed}" ] ; then
+    COMPREPLY=( $( compgen -f -- "$cur" ) $( compgen -d -- "$cur" ) )
+  else
+    COMPREPLY=( $(compgen -W "${completed}" -- ${cur}) )
+  fi
+  return 0
+}
+complete -o filenames -F _bs bs

--- a/test/dotbasespace/default-plugins.json
+++ b/test/dotbasespace/default-plugins.json
@@ -1,0 +1,1 @@
+{"third party": {}}

--- a/test/dotbasespace/default.cfg
+++ b/test/dotbasespace/default.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+apiServer = https://api.cloud-hoth.illumina.com/
+accessToken = __ACCESS_TOKEN__

--- a/test/dotbasespace/unit_tests-plugins.json
+++ b/test/dotbasespace/unit_tests-plugins.json
@@ -1,0 +1,1 @@
+{"third party": {}}

--- a/test/dotbasespace/unit_tests.cfg
+++ b/test/dotbasespace/unit_tests.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+apiServer = https://api.cloud-hoth.illumina.com/
+accessToken = __ACCESS_TOKEN__

--- a/test/launch_helpers_tests.py
+++ b/test/launch_helpers_tests.py
@@ -36,10 +36,10 @@ app_minimum_properties = [
     'sample-id',
 ]
 app_defaults = {
-    'AnnotationSource': u'RefSeq',
-    'genome-id': u'Human',
-    'GQX-id': u'30',
-    'StrandBias-id': u'10',
+    'AnnotationSource': 'RefSeq',
+    'genome-id': 'Human',
+    'GQX-id': '30',
+    'StrandBias-id': '10',
     'FlagPCRDuplicates-id': []
 }
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -7,79 +7,82 @@ from BaseSpacePy.api.APIClient import APIClient
 from BaseSpacePy.api.BaseSpaceAPI import BaseSpaceAPI
 from BaseSpacePy.model.QueryParameters import QueryParameters as qp
 
+import six
+
+
 class TestSDK(object):
     '''
     Compares objects from BaseSpace REST API to SDK objects, including pickled objects
     '''
-    def __init__(self):                                        
-        
+    def __init__(self):
+
         self.qp = {}
         self.rest_method = 'GET'
         self.postData = None
         self.headerParams=None
         self.list_request = False
-        
+
         # TODO change to unit_tests, but need to add projects/run to account?
-        self.myAPI = BaseSpaceAPI(profile="ps_native_hoth")        
-        self.api = APIClient(self.myAPI.getAccessToken(), self.myAPI.apiServer)        
+        self.myAPI = BaseSpaceAPI(profile="ps_native_hoth")
+        self.api = APIClient(self.myAPI.getAccessToken(), self.myAPI.apiServer)
 
     def compare_dict_to_obj(self, rest_dict, p_obj):
-        """ 
+        """
         Compare a dictionary from a REST API response and a SDK object for identity.
         """
-        for r_key, r_val in rest_dict.iteritems():
+        for r_key, r_val in six.iteritems(rest_dict):
             # confirm that the key from REST api exists in stored object
             try:
-                p_val = getattr(p_obj, r_key)                                      
+                p_val = getattr(p_obj, r_key)
             except AttributeError:
-                print "REST API attribute '" + r_key + "' doesn't exist in object"                            
+                print("REST API attribute '" + r_key + "' doesn't exist in object")
             else:
-                self.classify_rest_item(r_val, p_val, r_key)                    
+                self.classify_rest_item(r_val, p_val, r_key)
 
     def compare_list_to_obj(self, rest_list, p_obj, r_key):
-        """ 
+        """
         Compare a list from a REST API response and an SDK object for identity.
-        """                   
+        """
         if type(p_obj) != list:
-            print "Attribute '" + r_key + "' is a list in the REST API but not in the object"
+            print("Attribute '" + r_key + "' is a list in the REST API but not in the object")
         elif len(p_obj) != len(rest_list):
-            print "Attribute '" + r_key + "' has different list length between REST API and object"
+            print("Attribute '" + r_key + "' has different list length between REST API and object")
         else:
             for r_val, p_val in map(None, rest_list, p_obj):
                 self.classify_rest_item(r_val, p_val, r_key)
-                                                                        
+
     def compare_builtin_to_obj(self, rest_val, p_obj, r_key):
-        """ 
+        """
         Compare a built-in type from a REST API response and an SDK object for identity.
-        """                   
+        """
         # convert unicode to ascii for comparisons
-        if isinstance(rest_val, unicode):
+        if isinstance(rest_val, six.text_type):
             rest_val = rest_val.encode('ascii','ignore')
         # don't compare values for datetimes
         if r_key in ['DateCreated', 'DateModified', 'DateUploadCompleted', 'DateUploadStarted']:
             pass
-        elif rest_val != p_obj:                                
-            print "REST API attribute '" + r_key + "' has value '" + str(rest_val) + "' doesn't match object value '" + str(p_obj) + "'"                            
+        elif rest_val != p_obj:
+            print("REST API attribute '" + r_key + "' has value '" + str(rest_val) + "' doesn't match object value '" + str(p_obj) + "'")
 
     def classify_rest_item(self, r_val, p_val, r_key):
         """
         Determine the input REST item's type and call method to compare to input object
-        """                                        
-        if type(r_val) in [ int, str, bool, float, unicode]:                            
+        """
+        if type(r_val) in [ int, str, bool, float, six.text_type]:
             self.compare_builtin_to_obj(r_val, p_val, r_key)
-        elif type(r_val) == dict:            
+        elif type(r_val) == dict:
             self.compare_dict_to_obj(r_val, p_val)
-        elif type(r_val) == list:                                    
+        elif type(r_val) == list:
             self.compare_list_to_obj(r_val, p_val, r_key)
         else:
-            print "REST API attribute'" + r_key + "' has an unrecognized attribute type"                            
-        
+            print("REST API attribute'" + r_key + "' has an unrecognized attribute type")
+
     def test_rest_vs_sdk(self):
         """
         Compares REST API response and python SDK object for identify, for an API method
-        """        
+        """
         sdk_obj = self.call_sdk()
-        rest_obj = self.call_rest_api()                                                        
+        rest_obj = self.call_rest_api()
         # TODO passing Response here, SDK doesn't currently capture other items at this level (e.g. Notifications)
         if self.list_request:
             self.compare_list_to_obj(rest_obj['Response']['Items'], sdk_obj, "BASE")
@@ -96,18 +99,18 @@ class TestSDK(object):
         """
         Stores a pickled object in the provided path (include file name) for the object returned for this SDK method
         """
-        sdk_obj = self.call_sdk()        
+        sdk_obj = self.call_sdk()
         with open(pickle_path, 'w') as f:
             Pickle.dump(sdk_obj, f)
-            
+
     def get_pickle(self, pickle_path):
         """
         Retrieves a pickled object from the provided path (include file name), for this API test
-        """        
+        """
         with open(pickle_path, 'r') as f:
             sdk_obj = Pickle.load(f)
-        return sdk_obj        
-        
+        return sdk_obj
+
     def test_rest_vs_pickle(self, pickle_path):
         """
         Compares REST API response and a stored object for identify, for an API method
@@ -118,46 +121,46 @@ class TestSDK(object):
 
 class GetAppSessionById(TestSDK):
 
-    def __init__(self, bsid):        
+    def __init__(self, bsid):
         super(GetAppSessionById, self).__init__()
         self.rest_path = '/appsessions/' + bsid
-        
+
         self.appsession_id = bsid
 
     def call_sdk(self):
         return self.myAPI.getAppSessionById(self.appsession_id)
 
 class GetAppSessionPropertiesById(TestSDK):
-    
+
     def __init__(self, ssn_id, query_p={}):
         super(GetAppSessionPropertiesById, self).__init__()
         self.rest_path = '/appsessions/' + ssn_id + '/properties'
-        
+
         self.appsession_id = ssn_id
         self.qp = query_p
 
     def call_sdk(self):
-        return self.myAPI.getAppSessionPropertiesById(self.appsession_id, qp(self.qp))        
+        return self.myAPI.getAppSessionPropertiesById(self.appsession_id, qp(self.qp))
 
 class GetAppSessionPropertyByName(TestSDK):
 
     def __init__(self, ssn_id, prop_name, query_p={}):
         super(GetAppSessionPropertyByName, self).__init__()
         self.rest_path = '/appsessions/' + ssn_id + '/properties/' + prop_name + '/items'
-        
+
         self.appsession_id = ssn_id
         self.property_name = prop_name
         self.qp = query_p
 
     def call_sdk(self):
-        return self.myAPI.getAppSessionPropertyByName(self.appsession_id, qp(self.qp), self.property_name)        
+        return self.myAPI.getAppSessionPropertyByName(self.appsession_id, qp(self.qp), self.property_name)
 
 class GetRunById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetRunById, self).__init__()
         self.rest_path = '/runs/' + bsid
-        
+
         self.run_id = bsid
         self.qp = query_p
 
@@ -166,10 +169,10 @@ class GetRunById(TestSDK):
 
 class GetRunPropertiesById(TestSDK):
 
-    def __init__(self, ssn_id, query_p={}):        
+    def __init__(self, ssn_id, query_p={}):
         super(GetRunPropertiesById, self).__init__()
         self.rest_path = '/runs/' + ssn_id + '/properties'
-        
+
         self.run_id = ssn_id
         self.qp = query_p
 
@@ -178,10 +181,10 @@ class GetRunPropertiesById(TestSDK):
 
 class GetProjectById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetProjectById, self).__init__()
         self.rest_path = '/projects/' + bsid
-        
+
         self.project_id = bsid
         self.qp = query_p
 
@@ -190,10 +193,10 @@ class GetProjectById(TestSDK):
 
 class GetProjectPropertiesById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetProjectPropertiesById, self).__init__()
         self.rest_path = '/projects/' + bsid + '/properties'
-        
+
         self.project_id = bsid
         self.qp = query_p
 
@@ -202,10 +205,10 @@ class GetProjectPropertiesById(TestSDK):
 
 class GetSampleById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetSampleById, self).__init__()
         self.rest_path = '/samples/' + bsid
-        
+
         self.sample_id = bsid
         self.qp = query_p
 
@@ -214,10 +217,10 @@ class GetSampleById(TestSDK):
 
 class GetSamplePropertiesById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetSamplePropertiesById, self).__init__()
         self.rest_path = '/samples/' + bsid + '/properties'
-        
+
         self.sample_id = bsid
         self.qp = query_p
 
@@ -226,10 +229,10 @@ class GetSamplePropertiesById(TestSDK):
 
 class GetAppResultById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetAppResultById, self).__init__()
         self.rest_path = '/appresults/' + bsid
-        
+
         self.appresult_id = bsid
         self.qp = query_p
 
@@ -238,10 +241,10 @@ class GetAppResultById(TestSDK):
 
 class GetAppResultPropertiesById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetAppResultPropertiesById, self).__init__()
         self.rest_path = '/appresults/' + bsid + '/properties'
-        
+
         self.appresult_id = bsid
         self.qp = query_p
 
@@ -250,10 +253,10 @@ class GetAppResultPropertiesById(TestSDK):
 
 class GetFileById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetFileById, self).__init__()
         self.rest_path = '/files/' + bsid
-        
+
         self.file_id = bsid
         self.qp = query_p
 
@@ -262,10 +265,10 @@ class GetFileById(TestSDK):
 
 class GetFilePropertiesById(TestSDK):
 
-    def __init__(self, bsid, query_p={}):        
+    def __init__(self, bsid, query_p={}):
         super(GetFilePropertiesById, self).__init__()
         self.rest_path = '/files/' + bsid + '/properties'
-        
+
         self.file_id = bsid
         self.qp = query_p
 
@@ -273,26 +276,26 @@ class GetFilePropertiesById(TestSDK):
         return self.myAPI.getFilePropertiesById(self.file_id, qp(self.qp))
 
 class FilterVariantSet(TestSDK):
-    
-    def __init__(self, bsid, chrom, start_pos, end_pos, format ,query_p=None):        
+
+    def __init__(self, bsid, chrom, start_pos, end_pos, format ,query_p=None):
         super(FilterVariantSet, self).__init__()
-        self.rest_path = '/variantset/' + bsid + '/variants/' + chrom        
+        self.rest_path = '/variantset/' + bsid + '/variants/' + chrom
         if query_p is None:
             query_p = {}
-            
+
         self.file_id = bsid
         self.chrom = chrom
         self.start_pos = start_pos
         self.end_pos = end_pos
-        self.format = format        
+        self.format = format
         self.qp = copy.deepcopy(query_p)
         self.qp['StartPos'] = start_pos
         self.qp['EndPos'] = end_pos
         self.qp['Format'] = format
         self.list_request = True
-    
+
     def call_sdk(self):
-        return self.myAPI.filterVariantSet(self.file_id, self.chrom, self.start_pos, self.end_pos, self.format, qp(self.qp))    
+        return self.myAPI.filterVariantSet(self.file_id, self.chrom, self.start_pos, self.end_pos, self.format, qp(self.qp))
 
 
 class TestSuite(object):
@@ -307,73 +310,73 @@ class TestSuite(object):
         cfg = self.cfg
         try:
             self.tests.append((FilterVariantSet(cfg['vcf_id'], cfg['vcf_chr'], cfg['vcf_start'], cfg['vcf_end'], cfg['vcf_format'], cfg['query_p']), "with query parameter"))
-        except AttributeError:            
-            print "Skipping test FilterVariantSet -- missing input parameter"
+        except AttributeError:
+            print("Skipping test FilterVariantSet -- missing input parameter")
         try:
             self.tests.append((GetAppSessionById(cfg['ssn_id']), "test"))
         except AttributeError:
-            print "Skipping test GetAppSessionById -- missing input parameter"
+            print("Skipping test GetAppSessionById -- missing input parameter")
         try:
             self.tests.append((GetAppSessionPropertiesById(cfg['ssn_id'], cfg['query_p']), "with query parameter"))
         except AttributeError:
-            print "Skipping test GetAppSessionPropertiesById -- missing input parameter"
-        try:            
-            for key, value in cfg['multivalue_property_names'].iteritems():
+            print("Skipping test GetAppSessionPropertiesById -- missing input parameter")
+        try:
+            for key, value in six.iteritems(cfg['multivalue_property_names']):
                 self.tests.append((GetAppSessionPropertyByName(cfg['ssn_id'], value, cfg['query_p']), key))
         except AttributeError:
-            print "Skipping test GetAppSessionPropertiesByName -- missing input parameter"
+            print("Skipping test GetAppSessionPropertiesByName -- missing input parameter")
         try:
             self.tests.append((GetRunById(cfg['run_id'], cfg['query_p']), "with query parameter"))
         except AttributeError:
-            print "Skipping test GetRunById -- missing input parameter"
+            print("Skipping test GetRunById -- missing input parameter")
         try:
             self.tests.append((GetRunPropertiesById(cfg['run_id'], cfg['query_p']), "with query parameter"))
         except AttributeError:
-            print "Skipping test GetRunPropertiesById -- missing input parameter"
+            print("Skipping test GetRunPropertiesById -- missing input parameter")
         try:
             self.tests.append((GetProjectById(cfg['project_id'], cfg['query_p']), "with query parameter"))
         except AttributeError:
-            print "Skipping test GetProjectById -- missing input parameter"
+            print("Skipping test GetProjectById -- missing input parameter")
         try:
             self.tests.append((GetProjectPropertiesById(cfg['project_id'], cfg['query_p']), "with query parameter"))
-        except AttributeError:            
-            print "Skipping test GetProjectPropertiesById -- missing input parameter"
+        except AttributeError:
+            print("Skipping test GetProjectPropertiesById -- missing input parameter")
         try:
             self.tests.append((GetSampleById(cfg['sample_id'], cfg['query_p']), "with query parameter"))
         except AttributeError:
-            print "Skipping test GetSampleById -- missing input parameter"
+            print("Skipping test GetSampleById -- missing input parameter")
         try:
             self.tests.append((GetSamplePropertiesById(cfg['sample_id'], cfg['query_p']), "with query parameter"))
-        except AttributeError:            
-            print "Skipping test GetSamplePropertiesById -- missing input parameter"            
+        except AttributeError:
+            print("Skipping test GetSamplePropertiesById -- missing input parameter")
         try:
             self.tests.append((GetAppResultById(cfg['appresult_id'], cfg['query_p']), "with query parameter"))
         except AttributeError:
-            print "Skipping test GetAppResultById -- missing input parameter"
+            print("Skipping test GetAppResultById -- missing input parameter")
         try:
             self.tests.append((GetAppResultPropertiesById(cfg['appresult_id'], cfg['query_p']), "with query parameter"))
-        except AttributeError:            
-            print "Skipping test GetAppResultPropertiesById -- missing input parameter"            
+        except AttributeError:
+            print("Skipping test GetAppResultPropertiesById -- missing input parameter")
         try:
             self.tests.append((GetFileById(cfg['file_id'], cfg['query_p']), "with query parameter"))
         except AttributeError:
-            print "Skipping test GetFileById -- missing input parameter"
+            print("Skipping test GetFileById -- missing input parameter")
         try:
             self.tests.append((GetFilePropertiesById(cfg['file_id'], cfg['query_p']), "with query parameter"))
-        except AttributeError:            
-            print "Skipping test GetFilePropertiesById -- missing input parameter"          
+        except AttributeError:
+            print("Skipping test GetFilePropertiesById -- missing input parameter")
 
-    
+
     def test_rest_vs_sdk(self):
         for test in self.tests:
-            print "\nTesting REST vs SDK for " + test[0].__class__.__name__ + "' with comment '" + test[1] + "'"
+            print("\nTesting REST vs SDK for " + test[0].__class__.__name__ + "' with comment '" + test[1] + "'")
             try:
                 test[0].test_rest_vs_sdk()
             except Exception as e:
-                print "Exception: " + str(e)        
+                print("Exception: " + str(e))
 
 if __name__ == '__main__':
-        
+
     # BaseSaceAPI profile (in TestSDK.__init__) must have permission to read the items in cfg
     cfg = {}
     cfg['ssn_id'] = '1300310'
@@ -393,8 +396,8 @@ if __name__ == '__main__':
         'runs': 'Input.run-id2',
         #'map': None,
         'maps': 'Input.app-result-id2.attributes',
-    }                       
-    cfg['run_id'] = '523524' 
+    }
+    cfg['run_id'] = '523524'
     cfg['project_id'] = '2'
     cfg['sample_id'] = '1021'
     cfg['appresult_id'] = '21'
@@ -404,11 +407,10 @@ if __name__ == '__main__':
     cfg['vcf_start'] = '1'
     cfg['vcf_end'] = '4000'
     cfg['vcf_format'] = 'txt' # or 'vcf'
-    
-    
-    # Run all tests in the test suite for 'test_app1'    
+
+
+    # Run all tests in the test suite for 'test_app1'
     #suite = TestSuite(app_data.test_app1)
     suite = TestSuite(cfg)
     suite.add_tests()
-    suite.test_rest_vs_sdk()                
-    
+    suite.test_rest_vs_sdk()

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -2521,4 +2521,6 @@ if __name__ == "__main__":
         # to test individual test cases:
         for t in sys.argv[1:]:
             tests.append( TestLoader().loadTestsFromTestCase( eval(t) ) )
-    TextTestRunner(verbosity=2).run( TestSuite(tests) )
+    ret = TextTestRunner(verbosity=2).run( TestSuite(tests) )
+    exitcode = not ret.wasSuccessful()
+    sys.exit(exitcode)

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -219,8 +219,6 @@ class TestAPIFileUploadMethods_SmallFiles(TestCase):
             contentType=tconst['file_small_upload_content_type'])
         with open(tconst['file_small_upload']) as fp:
             out = fp.read()
-            # md5 = hashlib.md5(out).digest().encode('base64')
-            # import pdb;pdb.set_trace()
         md5 = base64.b64encode(hashlib.md5(out.encode('utf-8')).digest())
         response = self.api.__uploadMultipartUnit__(
             Id = file.Id,

--- a/test/unit_tests.py
+++ b/test/unit_tests.py
@@ -2140,9 +2140,9 @@ class TestAPIClientMethods(TestCase):
             fileName = os.path.basename(tconst['file_small_upload']),
             directory = testDir,
             contentType = tconst['file_small_upload_content_type'])
-        with open(tconst['file_small_upload']) as fp:
+        with open(tconst['file_small_upload'], "rb") as fp:
             out = fp.read()
-            md5 = hashlib.md5(out).digest().encode('base64')
+            md5 = base64.b64encode(hashlib.md5(out).digest())
 
         method                       = 'PUT'
         resourcePath                 = '/files/{Id}/parts/{partNumber}'
@@ -2236,9 +2236,9 @@ class TestAPIClientMethods(TestCase):
             fileName = os.path.basename(tconst['file_small_upload']),
             directory = testDir,
             contentType = tconst['file_small_upload_content_type'])
-        with open(tconst['file_small_upload']) as fp:
+        with open(tconst['file_small_upload'], "rb") as fp:
             out = fp.read()
-            md5 = hashlib.md5(out).digest().encode('base64')
+            md5 = base64.b64encode(hashlib.md5(out).digest())
 
         method                       = 'PUT'
         resourcePath                 = '/files/{Id}/parts/{partNumber}'


### PR DESCRIPTION
This pull request features:
- Code that is compatible with both python 2 and python 3, using the 
  [six](https://pythonhosted.org/six/) module
- [Passes unit tests](https://travis-ci.org/dtenenba/basespace-python-sdk/builds/169992638)
  under [python 2](https://travis-ci.org/dtenenba/basespace-python-sdk/jobs/169992639) and 
  [python 3](https://travis-ci.org/dtenenba/basespace-python-sdk/jobs/169992640).
- Includes Continuous Integration (CI) using [Travis](https://travis-ci.org) which runs unit tests
  on python 2 and 3 with every push.
- Also runs static analysis with [PyFlakes](https://pypi.python.org/pypi/pyflakes) but does not 
  currently fail CI if there are pyflakes warnings. This can be changed in future if desired.

After merging this pull request, further code should be written to be compatible with both
python 2 and python 3 (until/unless you decide to drop python 2 support). The 
six [documentation](https://pythonhosted.org/six/) tells you how to do this and
the CI support will run the tests for you to ensure that your changes still work
on both platforms.
## How to set up Travis CI

(You only need to do these things once.)
- Go to the [Travis](https://travis-ci.org) website
- Click "Sign in with GitHub" if you are not already signed in
- Click the "+" link next to "My Repositories"
- Click your organization if necessary and choose the "basespace-python-sdk" repository. Click the
  "on switch" to enable CI on this repository.
- Click on the repository, then mouse over "More Options" and click "Settings"
- Add an environment variable called `ACCESS_TOKEN` whose value should come
  from your `~/.basespace/unit_tests.cfg` file if you have set up your
  machine to run unit tests locally following the
  [instructions](https://github.com/basespace/basespace-python-sdk/blob/master/test/unit_tests.py#L22)
  in `test/unit_tests.py`. By default this variable will not show up in any test 
  logs so it is safe to do this.
- Edit the `README.md` file and replace `dtenenba` with your organization
  (presumably `basespace`) in the URL on the first line of the file. This will
  cause the Travis CI build badge to show up in the README. When you merge 
  the `develop` branch into `master`, you can get rid of the `?branch=develop` part of this line in
  the `master` branch.
- You are done! Subsequent pushes to the repository will run the CI build 
  (following the instructions in `.travis.yml`) and you 
  can go to the [Travis](https://travis-ci.org) website to see the results.

I hope you will consider this pull request. It was a fair amount of work but I learned a lot about porting code to be python 2 and 3 compatible, and about the basespace python SDK. It would be great if this was accepted so that users could use python 3 with the SDK if they so choose. Don't hesitate to let me know if you have any questions.
