### PR TITLE
If basespace.cfg doesn't exist, use constructor arguments

### DIFF
--- a/src/BaseSpacePy/api/BaseSpaceAPI.py
+++ b/src/BaseSpacePy/api/BaseSpaceAPI.py
@@ -132,7 +132,7 @@ class BaseSpaceAPI(BaseAPI):
         '''
         config_file = os.path.join(os.path.expanduser('~/.basespace'), "%s.cfg" % profile)
         if not os.path.exists(config_file):
-            raise CredentialsException("Could not find config file: %s" % config_file)
+            return {}
         section_name = "DEFAULT"
         cred = {}
         config = configparser.SafeConfigParser()


### PR DESCRIPTION
Currently, the basespacesdk will raise an exception if the profile config file is not found, even if the same credentials are provided through the constructor. This PR makes local credentials optional.